### PR TITLE
feat(api): add force-run endpoint for immediate job execution

### DIFF
--- a/crawler/internal/api/api.go
+++ b/crawler/internal/api/api.go
@@ -250,6 +250,10 @@ func setupCrawlerRoutes(
 	// Setup job routes
 	setupJobRoutes(v1, jobsHandler)
 
+	// API v2 routes (minimal: run-now only; same JWT protection)
+	v2 := infragin.ProtectedGroup(router, "/api/v2", jwtSecret)
+	v2.POST("/jobs/:id/force-run", jobsHandler.ForceRun)
+
 	// Setup log routes
 	setupLogRoutes(v1, logsHandler, logsV2Handler)
 

--- a/crawler/internal/api/jobs_handler.go
+++ b/crawler/internal/api/jobs_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -14,6 +15,15 @@ const (
 	defaultLimit  = 50
 	defaultOffset = 0
 	undefinedID   = "undefined"
+
+	// Job status values (for goconst)
+	statusPending   = "pending"
+	statusScheduled = "scheduled"
+	statusRunning   = "running"
+	statusPaused    = "paused"
+	statusCompleted = "completed"
+	statusFailed    = "failed"
+	statusCancelled = "cancelled"
 )
 
 // JobsHandler handles job-related HTTP requests.
@@ -114,9 +124,9 @@ func (h *JobsHandler) CreateJob(c *gin.Context) {
 	}
 
 	// Determine initial status
-	status := "pending"
+	status := statusPending
 	if req.IntervalMinutes != nil && req.ScheduleEnabled {
-		status = "scheduled"
+		status = statusScheduled
 	}
 
 	// Create job domain object
@@ -327,7 +337,7 @@ func (h *JobsHandler) CancelJob(c *gin.Context) {
 	// we still proceed to update the database status. The scheduler
 	// might not have the job if execution already finished or if the
 	// scheduler was restarted.
-	if job.Status == "running" && h.scheduler != nil {
+	if job.Status == statusRunning && h.scheduler != nil {
 		// Attempt to cancel - ignore "job not currently running" errors
 		// since the job may have finished between status check and cancel
 		_ = h.scheduler.CancelJob(id)
@@ -380,7 +390,7 @@ func (h *JobsHandler) RetryJob(c *gin.Context) {
 	}
 
 	// Reset job for retry
-	job.Status = "pending"
+	job.Status = statusPending
 	job.CurrentRetryCount = 0
 	job.ErrorMessage = nil
 	job.CompletedAt = nil
@@ -483,4 +493,46 @@ func (h *JobsHandler) GetSchedulerMetrics(c *gin.Context) {
 	response.StaleLocksCleared = metrics.StaleLocksCleared
 
 	c.JSON(http.StatusOK, response)
+}
+
+// ForceRun handles POST /api/v2/jobs/:id/force-run (run scheduled job now).
+// Sets next_run_at to now so the V1 interval scheduler picks the job up on its next poll.
+func (h *JobsHandler) ForceRun(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" || id == undefinedID {
+		respondBadRequest(c, "Invalid job ID")
+		return
+	}
+
+	job, err := h.repo.GetByID(c.Request.Context(), id)
+	if err != nil {
+		respondNotFound(c, "Job")
+		return
+	}
+
+	switch job.Status {
+	case statusRunning:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Job is already running"})
+		return
+	case statusCompleted, statusFailed, statusCancelled:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Job in terminal state: " + job.Status})
+		return
+	case statusScheduled, statusPaused, statusPending:
+		// allowed
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Job status cannot run now: " + job.Status})
+		return
+	}
+
+	now := time.Now()
+	job.NextRunAt = &now
+	if updateErr := h.repo.Update(c.Request.Context(), job); updateErr != nil {
+		respondInternalError(c, "Failed to schedule job for immediate run")
+		return
+	}
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"message": "Job queued for immediate execution",
+		"job_id":  job.ID,
+	})
 }

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -183,6 +183,7 @@ export const crawlerApi = {
     resume: (id: string | number) => crawlerClient.post(`/jobs/${id}/resume`),
     cancel: (id: string | number) => crawlerClient.post(`/jobs/${id}/cancel`),
     retry: (id: string | number) => crawlerClient.post(`/jobs/${id}/retry`),
+    forceRun: (id: string | number) => crawlerClient.post(`/v2/jobs/${id}/force-run`),
     // Log endpoints
     logs: (id: string | number, params?: { limit?: number; offset?: number }) =>
       crawlerClient.get(`/jobs/${id}/logs`, { params }),

--- a/dashboard/src/components/domain/jobs/JobsTable.vue
+++ b/dashboard/src/components/domain/jobs/JobsTable.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   Play,
+  PlayCircle,
   Pause,
   XCircle,
   RotateCcw,
@@ -40,6 +41,7 @@ const emit = defineEmits<{
   (e: 'view', job: Job): void
   (e: 'pause', job: Job): void
   (e: 'resume', job: Job): void
+  (e: 'runNow', job: Job): void
   (e: 'cancel', job: Job): void
   (e: 'retry', job: Job): void
   (e: 'delete', job: Job): void
@@ -124,6 +126,10 @@ function canCancel(job: Job): boolean {
 
 function canRetry(job: Job): boolean {
   return ['failed', 'cancelled'].includes(job.status)
+}
+
+function canRunNow(job: Job): boolean {
+  return ['scheduled', 'paused', 'pending'].includes(job.status)
 }
 
 function handleRowClick(job: Job) {
@@ -327,6 +333,13 @@ function goToPage(page: number | string) {
                   >
                     <Play class="mr-2 h-4 w-4" />
                     Resume
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    v-if="canRunNow(job)"
+                    @click="emit('runNow', job)"
+                  >
+                    <PlayCircle class="mr-2 h-4 w-4" />
+                    Run now
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     v-if="canCancel(job)"

--- a/dashboard/src/features/intake/api/jobs.ts
+++ b/dashboard/src/features/intake/api/jobs.ts
@@ -187,3 +187,10 @@ export async function cancelJob(id: string): Promise<void> {
 export async function retryJob(id: string): Promise<void> {
   await crawlerApi.jobs.retry(id)
 }
+
+/**
+ * Run a scheduled job now (force-run)
+ */
+export async function forceRunJob(id: string): Promise<void> {
+  await crawlerApi.jobs.forceRun(id)
+}

--- a/dashboard/src/features/intake/composables/useJobs.ts
+++ b/dashboard/src/features/intake/composables/useJobs.ts
@@ -47,6 +47,7 @@ import {
   useResumeJobMutation,
   useCancelJobMutation,
   useRetryJobMutation,
+  useForceRunJobMutation,
   useBulkPauseJobsMutation,
   useBulkDeleteJobsMutation,
 } from './useJobMutations'
@@ -78,6 +79,7 @@ export function useJobs() {
   const resumeMutation = useResumeJobMutation()
   const cancelMutation = useCancelJobMutation()
   const retryMutation = useRetryJobMutation()
+  const forceRunMutation = useForceRunJobMutation()
   const bulkPauseMutation = useBulkPauseJobsMutation()
   const bulkDeleteMutation = useBulkDeleteJobsMutation()
 
@@ -140,6 +142,10 @@ export function useJobs() {
 
   async function retryJob(id: string) {
     return retryMutation.mutateAsync(id)
+  }
+
+  async function forceRunJob(id: string) {
+    return forceRunMutation.mutateAsync(id)
   }
 
   async function bulkPauseJobs(ids: string[]) {
@@ -220,6 +226,7 @@ export function useJobs() {
     resumeJob,
     cancelJob,
     retryJob,
+    forceRunJob,
     bulkPauseJobs,
     bulkDeleteJobs,
 
@@ -231,6 +238,7 @@ export function useJobs() {
     isResuming: computed(() => resumeMutation.isPending.value),
     isCancelling: computed(() => cancelMutation.isPending.value),
     isRetrying: computed(() => retryMutation.isPending.value),
+    isForceRunning: computed(() => forceRunMutation.isPending.value),
 
     // Utilities
     refetch,
@@ -259,6 +267,7 @@ export function useJobDetail(jobId: string) {
   const resumeMutation = useResumeJobMutation()
   const cancelMutation = useCancelJobMutation()
   const retryMutation = useRetryJobMutation()
+  const forceRunMutation = useForceRunJobMutation()
   const deleteMutation = useDeleteJobMutation()
 
   return {
@@ -283,6 +292,7 @@ export function useJobDetail(jobId: string) {
     resumeJob: () => resumeMutation.mutateAsync(jobId),
     cancelJob: () => cancelMutation.mutateAsync(jobId),
     retryJob: () => retryMutation.mutateAsync(jobId),
+    forceRunJob: () => forceRunMutation.mutateAsync(jobId),
     deleteJob: () => deleteMutation.mutateAsync(jobId),
 
     // Mutation states
@@ -290,6 +300,7 @@ export function useJobDetail(jobId: string) {
     isResuming: computed(() => resumeMutation.isPending.value),
     isCancelling: computed(() => cancelMutation.isPending.value),
     isRetrying: computed(() => retryMutation.isPending.value),
+    isForceRunning: computed(() => forceRunMutation.isPending.value),
     isDeleting: computed(() => deleteMutation.isPending.value),
 
     // UI

--- a/dashboard/src/views/intake/JobDetailView.vue
+++ b/dashboard/src/views/intake/JobDetailView.vue
@@ -8,7 +8,7 @@
  */
 import { computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ArrowLeft, Pause, Play, XCircle, RotateCcw, Loader2 } from 'lucide-vue-next'
+import { ArrowLeft, Pause, Play, PlayCircle, XCircle, RotateCcw, Loader2 } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -93,6 +93,11 @@ const canRetry = computed(() => {
   return ['completed', 'failed', 'cancelled'].includes(job.value.status)
 })
 
+const canRunNow = computed(() => {
+  if (!job.value) return false
+  return ['scheduled', 'paused', 'pending'].includes(job.value.status)
+})
+
 async function handlePause() {
   await detail.pauseJob()
 }
@@ -107,6 +112,10 @@ async function handleCancel() {
 
 async function handleRetry() {
   await detail.retryJob()
+}
+
+async function handleRunNow() {
+  await detail.forceRunJob()
 }
 
 function goBack() {
@@ -167,6 +176,22 @@ function goBack() {
             class="mr-2 h-4 w-4"
           />
           Resume
+        </Button>
+        <Button
+          v-if="canRunNow"
+          variant="outline"
+          :disabled="detail.isForceRunning.value"
+          @click="handleRunNow"
+        >
+          <Loader2
+            v-if="detail.isForceRunning.value"
+            class="mr-2 h-4 w-4 animate-spin"
+          />
+          <PlayCircle
+            v-else
+            class="mr-2 h-4 w-4"
+          />
+          Run now
         </Button>
         <Button
           v-if="canRetry"

--- a/dashboard/src/views/intake/JobsView.vue
+++ b/dashboard/src/views/intake/JobsView.vue
@@ -146,6 +146,10 @@ async function handleRetry(job: Job) {
   await jobs.retryJob(job.id)
 }
 
+async function handleRunNow(job: Job) {
+  await jobs.forceRunJob(job.id)
+}
+
 // Auto-open create modal if ?create=true in URL
 watch(() => route.query.create, (create) => {
   if (create === 'true') {
@@ -256,6 +260,7 @@ watch(() => route.query.create, (create) => {
             @view="handleView"
             @pause="handlePause"
             @resume="handleResume"
+            @run-now="handleRunNow"
             @cancel="handleCancel"
             @retry="handleRetry"
             @delete="confirmDelete"

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -179,6 +179,20 @@ http {
             proxy_connect_timeout 75s;
         }
 
+        # Crawler API v2 (run-now etc.; must be before general /api/crawler)
+        location /api/crawler/v2 {
+            rewrite ^/api/crawler/v2(/.*)?$ /api/v2$1 break;
+            proxy_pass http://$crawler_api;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+            proxy_read_timeout 300s;
+            proxy_connect_timeout 75s;
+        }
+
         # Crawler API
         location /api/crawler {
             rewrite ^/api/crawler(/.*)?$ /api/v1$1 break;

--- a/infrastructure/nginx/nginx.dev.conf
+++ b/infrastructure/nginx/nginx.dev.conf
@@ -94,6 +94,20 @@ http {
         }
 
         # API proxy routes
+        # Crawler API v2 (run-now etc.; must be before general /api/crawler)
+        location /api/crawler/v2 {
+            rewrite ^/api/crawler/v2(/.*)?$ /api/v2$1 break;
+            proxy_pass http://$crawler_api;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+            proxy_read_timeout 300s;
+            proxy_connect_timeout 75s;
+        }
+
         # Crawler API
         location /api/crawler {
             rewrite ^/api/crawler(/.*)?$ /api/v1$1 break;


### PR DESCRIPTION
Changes:
- Introduced a new API v2 route `/api/v2/jobs/:id/force-run` to allow immediate execution of scheduled jobs.
- Updated JobsHandler to handle the force-run logic, including validation of job status.
- Enhanced the Scheduler to support immediate job execution for jobs in scheduled, paused, or pending states.
- Updated frontend components to integrate the new force-run functionality, including UI elements and API calls.

This feature improves job management by enabling users to run jobs immediately when needed.