### PR TITLE
feat(indexes): add server-side pagination, filtering, and sorting

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -371,7 +371,16 @@ export const indexManagerApi = {
 
   // Index operations
   indexes: {
-    list: (params?: { type?: string; source?: string }): Promise<AxiosResponse<ListIndexesResponse>> =>
+    list: (params?: {
+      limit?: number
+      offset?: number
+      sortBy?: string
+      sortOrder?: 'asc' | 'desc'
+      search?: string
+      type?: string
+      health?: string
+      source?: string
+    }): Promise<AxiosResponse<ListIndexesResponse>> =>
       indexManagerClient.get('/api/v1/indexes', { params }),
     get: (indexName: string): Promise<AxiosResponse<GetIndexResponse>> =>
       indexManagerClient.get(`/api/v1/indexes/${indexName}`),

--- a/dashboard/src/features/intelligence/api/indexes.ts
+++ b/dashboard/src/features/intelligence/api/indexes.ts
@@ -1,0 +1,52 @@
+import { indexManagerApi } from '@/api/client'
+import type { Index, IndexStats, HealthStatus, IndexType, IndexFilters } from '@/types/indexManager'
+import type { FetchParams, PaginatedResponse } from '@/types/table'
+
+// Query key factory for TanStack Query cache management
+export const indexesKeys = {
+  all: ['indexes'] as const,
+  lists: () => [...indexesKeys.all, 'list'] as const,
+  list: (filters?: IndexFilters) => [...indexesKeys.lists(), filters] as const,
+  details: () => [...indexesKeys.all, 'detail'] as const,
+  detail: (name: string) => [...indexesKeys.details(), name] as const,
+  stats: () => [...indexesKeys.all, 'stats'] as const,
+}
+
+// Fetch indexes with pagination/sorting/filtering
+export async function fetchIndexes(
+  params: FetchParams<IndexFilters>
+): Promise<PaginatedResponse<Index>> {
+  const queryParams: Record<string, unknown> = {
+    limit: params.limit,
+    offset: params.offset,
+    sortBy: params.sortBy,
+    sortOrder: params.sortOrder,
+  }
+
+  // Add filters
+  if (params.filters?.search) queryParams.search = params.filters.search
+  if (params.filters?.type) queryParams.type = params.filters.type
+  if (params.filters?.health) queryParams.health = params.filters.health
+  if (params.filters?.source) queryParams.source = params.filters.source
+
+  const response = await indexManagerApi.indexes.list(queryParams as Parameters<typeof indexManagerApi.indexes.list>[0])
+
+  return {
+    items: response.data?.indices ?? [],
+    total: response.data?.total ?? 0,
+  }
+}
+
+// Fetch stats for cards
+export async function fetchIndexStats(): Promise<IndexStats> {
+  const response = await indexManagerApi.stats.get()
+  return response.data
+}
+
+// Delete index
+export async function deleteIndex(name: string): Promise<void> {
+  await indexManagerApi.indexes.delete(name)
+}
+
+// Re-export types for convenience
+export type { Index, IndexStats, HealthStatus, IndexType, IndexFilters }

--- a/dashboard/src/features/intelligence/components/IndexStatsCards.vue
+++ b/dashboard/src/features/intelligence/components/IndexStatsCards.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import {
+  Database,
+  FileText,
+  HardDrive,
+  Activity,
+} from 'lucide-vue-next'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { IndexStats } from '@/types/indexManager'
+
+interface Props {
+  stats: IndexStats | undefined
+  loading?: boolean
+}
+
+withDefaults(defineProps<Props>(), {
+  loading: false,
+})
+
+function formatNumber(num: number | undefined): string {
+  if (num === undefined) return '0'
+  if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M'
+  if (num >= 1000) return (num / 1000).toFixed(1) + 'K'
+  return num.toLocaleString()
+}
+
+</script>
+
+<template>
+  <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+    <!-- Total Indexes -->
+    <div class="rounded-lg border bg-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="rounded-lg bg-blue-500/10 p-2">
+          <Database class="h-5 w-5 text-blue-500" />
+        </div>
+        <div>
+          <Skeleton
+            v-if="loading"
+            class="mb-1 h-7 w-12"
+          />
+          <div
+            v-else
+            class="text-2xl font-bold tabular-nums"
+          >
+            {{ stats?.total_indexes ?? 0 }}
+          </div>
+          <div class="text-xs text-muted-foreground uppercase tracking-wider">
+            Indexes
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Total Documents -->
+    <div class="rounded-lg border bg-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="rounded-lg bg-violet-500/10 p-2">
+          <FileText class="h-5 w-5 text-violet-500" />
+        </div>
+        <div>
+          <Skeleton
+            v-if="loading"
+            class="mb-1 h-7 w-16"
+          />
+          <div
+            v-else
+            class="text-2xl font-bold tabular-nums"
+          >
+            {{ formatNumber(stats?.total_documents) }}
+          </div>
+          <div class="text-xs text-muted-foreground uppercase tracking-wider">
+            Documents
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Indexed Today -->
+    <div class="rounded-lg border bg-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="rounded-lg bg-cyan-500/10 p-2">
+          <HardDrive class="h-5 w-5 text-cyan-500" />
+        </div>
+        <div>
+          <Skeleton
+            v-if="loading"
+            class="mb-1 h-7 w-16"
+          />
+          <div
+            v-else
+            class="text-2xl font-bold tabular-nums"
+          >
+            {{ formatNumber(stats?.indexed_today) }}
+          </div>
+          <div class="text-xs text-muted-foreground uppercase tracking-wider">
+            Today
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Health Status -->
+    <div class="rounded-lg border bg-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="rounded-lg bg-emerald-500/10 p-2">
+          <Activity class="h-5 w-5 text-emerald-500" />
+        </div>
+        <div>
+          <Skeleton
+            v-if="loading"
+            class="mb-1 h-7 w-24"
+          />
+          <div
+            v-else
+            class="flex items-center gap-2"
+          >
+            <div class="flex items-center gap-1">
+              <span class="inline-block h-2 w-2 rounded-full bg-emerald-400" />
+              <span class="text-sm font-semibold text-emerald-500">
+                {{ stats?.indexes_by_health?.green ?? 0 }}
+              </span>
+            </div>
+            <div class="flex items-center gap-1">
+              <span class="inline-block h-2 w-2 rounded-full bg-amber-400" />
+              <span class="text-sm font-semibold text-amber-500">
+                {{ stats?.indexes_by_health?.yellow ?? 0 }}
+              </span>
+            </div>
+            <div class="flex items-center gap-1">
+              <span class="inline-block h-2 w-2 rounded-full bg-rose-400" />
+              <span class="text-sm font-semibold text-rose-500">
+                {{ stats?.indexes_by_health?.red ?? 0 }}
+              </span>
+            </div>
+          </div>
+          <div class="text-xs text-muted-foreground uppercase tracking-wider">
+            Health Status
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/dashboard/src/features/intelligence/components/IndexesFilterBar.vue
+++ b/dashboard/src/features/intelligence/components/IndexesFilterBar.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { Search, X, Filter } from 'lucide-vue-next'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useIndexes } from '../composables/useIndexes'
+import type { IndexType, HealthStatus } from '@/types/indexManager'
+
+const indexes = useIndexes()
+
+const typeOptions: Array<{ value: IndexType | ''; label: string }> = [
+  { value: '', label: 'All Types' },
+  { value: 'raw_content', label: 'Raw Content' },
+  { value: 'classified_content', label: 'Classified Content' },
+  { value: 'article', label: 'Article' },
+  { value: 'page', label: 'Page' },
+]
+
+const healthOptions: Array<{ value: HealthStatus | ''; label: string; color: string }> = [
+  { value: '', label: 'All Health', color: 'bg-gray-400' },
+  { value: 'green', label: 'Green', color: 'bg-emerald-500' },
+  { value: 'yellow', label: 'Yellow', color: 'bg-amber-500' },
+  { value: 'red', label: 'Red', color: 'bg-rose-500' },
+]
+
+function handleSearchInput(value: string) {
+  indexes.setFilter('search', value || undefined)
+}
+
+function handleTypeChange(event: Event) {
+  const target = event.target as HTMLSelectElement
+  indexes.setFilter('type', (target.value as IndexType) || undefined)
+}
+
+function toggleHealthFilter(health: HealthStatus | '') {
+  if (health === '') {
+    indexes.setFilter('health', undefined)
+  } else if (indexes.filters.value.health === health) {
+    indexes.setFilter('health', undefined)
+  } else {
+    indexes.setFilter('health', health)
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <!-- Search and Type Filter Row -->
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <!-- Search Input -->
+      <div class="relative flex-1">
+        <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          :model-value="indexes.filters.value.search || ''"
+          placeholder="Search indexes by name..."
+          class="pl-9"
+          @update:model-value="handleSearchInput"
+        />
+      </div>
+
+      <!-- Type Filter -->
+      <div class="sm:w-48">
+        <select
+          :value="indexes.filters.value.type || ''"
+          class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          @change="handleTypeChange"
+        >
+          <option
+            v-for="option in typeOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+
+      <!-- Clear Filters Button -->
+      <Button
+        v-if="indexes.hasActiveFilters.value"
+        variant="outline"
+        size="sm"
+        class="shrink-0"
+        @click="indexes.clearFilters()"
+      >
+        <X class="mr-1 h-4 w-4" />
+        Clear ({{ indexes.activeFilterCount.value }})
+      </Button>
+    </div>
+
+    <!-- Health Filter Pills -->
+    <div class="flex flex-wrap items-center gap-2">
+      <div class="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <Filter class="h-4 w-4" />
+        <span>Health:</span>
+      </div>
+
+      <button
+        v-for="option in healthOptions"
+        :key="option.value"
+        :class="[
+          'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+          (option.value === '' && !indexes.filters.value.health) || indexes.filters.value.health === option.value
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-muted-foreground hover:bg-muted/80',
+        ]"
+        @click="toggleHealthFilter(option.value)"
+      >
+        <span
+          :class="['h-2 w-2 rounded-full', option.color]"
+        />
+        {{ option.label }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/dashboard/src/features/intelligence/components/IndexesTable.vue
+++ b/dashboard/src/features/intelligence/components/IndexesTable.vue
@@ -1,0 +1,351 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  ChevronLeft,
+  ChevronRight,
+  MoreHorizontal,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  Trash2,
+  Eye,
+  Database,
+} from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useIndexes } from '../composables/useIndexes'
+import type { Index, HealthStatus } from '@/types/indexManager'
+
+interface Props {
+  showActions?: boolean
+  onRowClick?: (index: Index) => void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showActions: true,
+  onRowClick: undefined,
+})
+
+const emit = defineEmits<{
+  (e: 'view', index: Index): void
+  (e: 'delete', index: Index): void
+}>()
+
+const router = useRouter()
+const indexes = useIndexes()
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning'
+
+const healthVariants: Record<HealthStatus, BadgeVariant> = {
+  green: 'success',
+  yellow: 'warning',
+  red: 'destructive',
+}
+
+// Define sortable columns
+const sortableColumns = [
+  { key: 'name', label: 'Name' },
+  { key: 'type', label: 'Type' },
+  { key: 'health', label: 'Health' },
+  { key: 'document_count', label: 'Documents' },
+  { key: 'size', label: 'Size' },
+] as const
+
+function getSortIcon(column: string) {
+  if (indexes.sortBy.value !== column) return ArrowUpDown
+  return indexes.sortOrder.value === 'asc' ? ArrowUp : ArrowDown
+}
+
+function handleSort(column: string) {
+  indexes.toggleSort(column)
+}
+
+const pageNumbers = computed(() => {
+  const current = indexes.page.value
+  const total = indexes.totalPages.value
+  const pages: (number | string)[] = []
+
+  if (total <= 7) {
+    for (let i = 1; i <= total; i++) pages.push(i)
+  } else {
+    pages.push(1)
+    if (current > 3) pages.push('...')
+    for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) {
+      pages.push(i)
+    }
+    if (current < total - 2) pages.push('...')
+    pages.push(total)
+  }
+
+  return pages
+})
+
+function formatNumber(num: number | undefined): string {
+  if (num === undefined) return '0'
+  return num.toLocaleString()
+}
+
+function formatType(type: string): string {
+  return type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
+}
+
+function handleRowClick(index: Index) {
+  if (props.onRowClick) {
+    props.onRowClick(index)
+  } else {
+    router.push({ name: 'intelligence-index-detail', params: { index_name: index.name } })
+  }
+}
+
+function goToPage(page: number | string) {
+  if (typeof page === 'number') {
+    indexes.setPage(page)
+  }
+}
+
+function handlePageSizeChange(event: Event) {
+  const target = event.target as HTMLSelectElement
+  indexes.setPageSize(Number(target.value))
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- Table -->
+    <div class="rounded-md border">
+      <table class="w-full">
+        <thead>
+          <tr class="border-b bg-muted/50">
+            <th
+              v-for="col in sortableColumns"
+              :key="col.key"
+              class="px-4 py-3 text-left text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+              @click="handleSort(col.key)"
+            >
+              <div class="flex items-center gap-1">
+                {{ col.label }}
+                <component
+                  :is="getSortIcon(col.key)"
+                  :class="[
+                    'h-4 w-4',
+                    indexes.sortBy.value === col.key ? 'text-foreground' : 'text-muted-foreground/50'
+                  ]"
+                />
+              </div>
+            </th>
+            <th
+              v-if="showActions"
+              class="px-4 py-3 text-right text-sm font-medium text-muted-foreground"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- Loading State -->
+          <template v-if="indexes.isLoading.value">
+            <tr
+              v-for="i in 5"
+              :key="i"
+              class="border-b"
+            >
+              <td class="px-4 py-3">
+                <Skeleton class="h-4 w-48" />
+              </td>
+              <td class="px-4 py-3">
+                <Skeleton class="h-4 w-24" />
+              </td>
+              <td class="px-4 py-3">
+                <Skeleton class="h-5 w-16" />
+              </td>
+              <td class="px-4 py-3">
+                <Skeleton class="h-4 w-20" />
+              </td>
+              <td class="px-4 py-3">
+                <Skeleton class="h-4 w-16" />
+              </td>
+              <td
+                v-if="showActions"
+                class="px-4 py-3"
+              >
+                <Skeleton class="ml-auto h-8 w-8" />
+              </td>
+            </tr>
+          </template>
+
+          <!-- Empty State -->
+          <tr v-else-if="indexes.indexes.value.length === 0">
+            <td
+              :colspan="showActions ? 6 : 5"
+              class="px-4 py-12 text-center"
+            >
+              <div class="flex flex-col items-center gap-2">
+                <Database class="h-8 w-8 text-muted-foreground" />
+                <p class="text-sm text-muted-foreground">
+                  {{ indexes.hasActiveFilters.value ? 'No indexes match your filters' : 'No indexes found' }}
+                </p>
+                <Button
+                  v-if="indexes.hasActiveFilters.value"
+                  variant="outline"
+                  size="sm"
+                  @click="indexes.clearFilters()"
+                >
+                  Clear filters
+                </Button>
+              </div>
+            </td>
+          </tr>
+
+          <!-- Data Rows -->
+          <tr
+            v-for="index in indexes.indexes.value"
+            v-else
+            :key="index.name"
+            class="border-b transition-colors hover:bg-muted/50 cursor-pointer"
+            @click="handleRowClick(index)"
+          >
+            <td class="px-4 py-3">
+              <code class="rounded bg-muted px-1.5 py-0.5 text-sm font-mono">
+                {{ index.name }}
+              </code>
+            </td>
+            <td class="px-4 py-3 text-sm text-muted-foreground">
+              {{ formatType(index.type) }}
+            </td>
+            <td class="px-4 py-3">
+              <Badge
+                v-if="index.health"
+                :variant="healthVariants[index.health]"
+              >
+                {{ index.health }}
+              </Badge>
+              <span
+                v-else
+                class="text-sm text-muted-foreground"
+              >—</span>
+            </td>
+            <td class="px-4 py-3 text-sm tabular-nums">
+              {{ formatNumber(index.document_count) }}
+            </td>
+            <td class="px-4 py-3 text-sm text-muted-foreground">
+              {{ index.size || '—' }}
+            </td>
+            <td
+              v-if="showActions"
+              class="px-4 py-3 text-right"
+              @click.stop
+            >
+              <DropdownMenu>
+                <DropdownMenuTrigger as-child>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    class="h-8 w-8 p-0"
+                  >
+                    <MoreHorizontal class="h-4 w-4" />
+                    <span class="sr-only">Open menu</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem @click="emit('view', index)">
+                    <Eye class="mr-2 h-4 w-4" />
+                    View Details
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    class="text-destructive focus:text-destructive"
+                    @click="emit('delete', index)"
+                  >
+                    <Trash2 class="mr-2 h-4 w-4" />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div
+      v-if="indexes.totalPages.value > 1 || indexes.totalIndexes.value > 0"
+      class="flex items-center justify-between border-t pt-4"
+    >
+      <p class="text-sm text-muted-foreground">
+        Showing {{ (indexes.page.value - 1) * indexes.pageSize.value + 1 }} to
+        {{ Math.min(indexes.page.value * indexes.pageSize.value, indexes.totalIndexes.value) }}
+        of {{ indexes.totalIndexes.value }} indexes
+      </p>
+
+      <div class="flex items-center gap-4">
+        <!-- Page Size Selector -->
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-muted-foreground">Show:</span>
+          <select
+            :value="indexes.pageSize.value"
+            class="rounded-md border bg-background px-2 py-1 text-sm"
+            @change="handlePageSizeChange"
+          >
+            <option
+              v-for="size in indexes.allowedPageSizes"
+              :key="size"
+              :value="size"
+            >
+              {{ size }}
+            </option>
+          </select>
+        </div>
+
+        <!-- Page Numbers -->
+        <div class="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            :disabled="indexes.page.value === 1"
+            @click="goToPage(indexes.page.value - 1)"
+          >
+            <ChevronLeft class="h-4 w-4" />
+          </Button>
+
+          <template
+            v-for="page in pageNumbers"
+            :key="page"
+          >
+            <Button
+              v-if="typeof page === 'number'"
+              :variant="page === indexes.page.value ? 'default' : 'outline'"
+              size="sm"
+              class="min-w-9"
+              @click="goToPage(page)"
+            >
+              {{ page }}
+            </Button>
+            <span
+              v-else
+              class="px-2 text-muted-foreground"
+            >...</span>
+          </template>
+
+          <Button
+            variant="outline"
+            size="sm"
+            :disabled="indexes.page.value === indexes.totalPages.value"
+            @click="goToPage(indexes.page.value + 1)"
+          >
+            <ChevronRight class="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/dashboard/src/features/intelligence/composables/index.ts
+++ b/dashboard/src/features/intelligence/composables/index.ts
@@ -1,0 +1,1 @@
+export { useIndexes } from './useIndexes'

--- a/dashboard/src/features/intelligence/composables/useIndexes.ts
+++ b/dashboard/src/features/intelligence/composables/useIndexes.ts
@@ -1,0 +1,105 @@
+import { computed } from 'vue'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { useServerPaginatedTable } from '@/composables/useServerPaginatedTable'
+import { fetchIndexes, fetchIndexStats, deleteIndex, indexesKeys } from '../api/indexes'
+import type { Index, IndexFilters } from '@/types/indexManager'
+
+const INDEXES_SORT_FIELDS = ['name', 'document_count', 'size', 'health', 'type']
+
+export function useIndexes() {
+  const queryClient = useQueryClient()
+
+  // Server-paginated table
+  const table = useServerPaginatedTable<Index, IndexFilters>({
+    fetchFn: fetchIndexes,
+    queryKeyPrefix: 'indexes',
+    defaultLimit: 25,
+    defaultSortBy: 'name',
+    defaultSortOrder: 'asc',
+    allowedSortFields: INDEXES_SORT_FIELDS,
+    allowedPageSizes: [10, 25, 50, 100],
+  })
+
+  // Stats query (for cards)
+  const statsQuery = useQuery({
+    queryKey: indexesKeys.stats(),
+    queryFn: fetchIndexStats,
+    staleTime: 30_000, // 30 seconds
+  })
+
+  // Delete mutation
+  const deleteMutation = useMutation({
+    mutationFn: deleteIndex,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: indexesKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: indexesKeys.stats() })
+    },
+  })
+
+  // Helper: Set a single filter
+  function setFilter<K extends keyof IndexFilters>(key: K, value: IndexFilters[K]) {
+    table.setFilters({ [key]: value } as Partial<IndexFilters>)
+  }
+
+  // Helper: Check if filters are active
+  const hasActiveFilters = computed(() => {
+    const f = table.filters.value
+    return !!(f.search || f.type || f.health || f.source)
+  })
+
+  // Helper: Count active filters
+  const activeFilterCount = computed(() => {
+    const f = table.filters.value
+    let count = 0
+    if (f.search) count++
+    if (f.type) count++
+    if (f.health) count++
+    if (f.source) count++
+    return count
+  })
+
+  return {
+    // Data
+    indexes: table.items,
+    totalIndexes: table.total,
+    stats: computed(() => statsQuery.data.value),
+    statsLoading: computed(() => statsQuery.isLoading.value),
+    isLoading: table.isLoading,
+    isFetching: table.isRefetching,
+    error: table.error,
+    hasError: table.hasError,
+
+    // Pagination
+    page: table.page,
+    pageSize: table.pageSize,
+    totalPages: table.totalPages,
+    hasNextPage: table.hasNextPage,
+    hasPreviousPage: table.hasPreviousPage,
+    allowedPageSizes: table.allowedPageSizes,
+    setPage: table.setPage,
+    setPageSize: table.setPageSize,
+    nextPage: table.nextPage,
+    prevPage: table.prevPage,
+
+    // Sorting
+    sortBy: table.sortBy,
+    sortOrder: table.sortOrder,
+    toggleSort: table.toggleSort,
+
+    // Filters
+    filters: table.filters,
+    setFilter,
+    setFilters: table.setFilters,
+    clearFilters: table.clearFilters,
+    hasActiveFilters,
+    activeFilterCount,
+
+    // Mutations
+    deleteIndex: (name: string) => deleteMutation.mutateAsync(name),
+    isDeleting: computed(() => deleteMutation.isPending.value),
+
+    // Utilities
+    refetch: table.refetch,
+    reset: table.reset,
+  }
+}

--- a/dashboard/src/features/intelligence/index.ts
+++ b/dashboard/src/features/intelligence/index.ts
@@ -1,0 +1,11 @@
+// API
+export { fetchIndexes, fetchIndexStats, deleteIndex, indexesKeys } from './api/indexes'
+export type { IndexFilters } from './api/indexes'
+
+// Composables
+export { useIndexes } from './composables/useIndexes'
+
+// Components
+export { default as IndexesFilterBar } from './components/IndexesFilterBar.vue'
+export { default as IndexesTable } from './components/IndexesTable.vue'
+export { default as IndexStatsCards } from './components/IndexStatsCards.vue'

--- a/dashboard/src/types/indexManager.ts
+++ b/dashboard/src/types/indexManager.ts
@@ -31,10 +31,20 @@ export interface CreateSourceIndexesRequest {
   index_types?: IndexType[]
 }
 
+// Filter Types
+export interface IndexFilters {
+  search?: string
+  type?: IndexType
+  health?: HealthStatus
+  source?: string
+}
+
 // Response Types
 export interface ListIndexesResponse {
   indices: Index[]
-  count: number
+  total: number
+  limit: number
+  offset: number
 }
 
 export interface GetIndexResponse extends Index {}

--- a/dashboard/src/views/intelligence/IndexesView.vue
+++ b/dashboard/src/views/intelligence/IndexesView.vue
@@ -1,222 +1,86 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import {
-  Loader2,
   Database,
   RefreshCw,
-  Trash2,
   AlertTriangle,
-  HardDrive,
-  FileText,
-  Activity,
-  Layers,
-  Search,
-  Filter
+  Loader2,
 } from 'lucide-vue-next'
-import { indexManagerApi } from '@/api/client'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import {
+  useIndexes,
+  IndexStatsCards,
+  IndexesFilterBar,
+  IndexesTable,
+} from '@/features/intelligence'
 import type { Index } from '@/types/indexManager'
 
-interface DisplayIndex {
-  name: string
-  document_count: number
-  size: string
-  sizeBytes: number
-  health: string
-  type: string
-}
-
 const router = useRouter()
-const loading = ref(true)
-const error = ref<string | null>(null)
-const indexes = ref<DisplayIndex[]>([])
-const searchQuery = ref('')
-const filterType = ref<string | null>(null)
+const indexes = useIndexes()
 
 // Delete confirmation state
 const deleteModalOpen = ref(false)
-const indexToDelete = ref<string | null>(null)
-const deleting = ref(false)
+const indexToDelete = ref<Index | null>(null)
 const deleteError = ref<string | null>(null)
 
-// Parse size string to bytes for sorting
-const parseSizeToBytes = (size: string): number => {
-  const match = size.match(/^([\d.]+)\s*([KMGT]?B)$/i)
-  if (!match) return 0
-  const value = parseFloat(match[1])
-  const unit = match[2].toUpperCase()
-  const multipliers: Record<string, number> = {
-    'B': 1,
-    'KB': 1024,
-    'MB': 1024 * 1024,
-    'GB': 1024 * 1024 * 1024,
-    'TB': 1024 * 1024 * 1024 * 1024
-  }
-  return value * (multipliers[unit] || 1)
+function handleView(index: Index) {
+  router.push({ name: 'intelligence-index-detail', params: { index_name: index.name } })
 }
 
-const loadIndexes = async () => {
-  try {
-    loading.value = true
-    error.value = null
-    const response = await indexManagerApi.indexes.list()
-    const rawIndices: Index[] = response.data?.indices || []
-    indexes.value = rawIndices.map((idx) => ({
-      name: idx.name,
-      document_count: idx.document_count || 0,
-      size: idx.size || '0 B',
-      sizeBytes: parseSizeToBytes(idx.size || '0 B'),
-      health: idx.health || 'unknown',
-      type: idx.type || 'unknown',
-    }))
-  } catch (err) {
-    console.error('Failed to load indexes:', err)
-    error.value = 'Unable to load Elasticsearch indexes.'
-  } finally {
-    loading.value = false
-  }
-}
-
-// Filtered and sorted indexes
-const filteredIndexes = computed(() => {
-  let result = [...indexes.value]
-
-  if (searchQuery.value) {
-    const query = searchQuery.value.toLowerCase()
-    result = result.filter(idx => idx.name.toLowerCase().includes(query))
-  }
-
-  if (filterType.value) {
-    result = result.filter(idx => idx.type === filterType.value)
-  }
-
-  return result
-})
-
-// Statistics
-const stats = computed(() => {
-  const total = indexes.value.length
-  const totalDocs = indexes.value.reduce((sum, idx) => sum + idx.document_count, 0)
-  const totalSize = indexes.value.reduce((sum, idx) => sum + idx.sizeBytes, 0)
-  const healthCounts = {
-    green: indexes.value.filter(i => i.health === 'green').length,
-    yellow: indexes.value.filter(i => i.health === 'yellow').length,
-    red: indexes.value.filter(i => i.health === 'red').length,
-  }
-  return { total, totalDocs, totalSize, healthCounts }
-})
-
-const formatSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B'
-  const k = 1024
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
-}
-
-const formatNumber = (num: number): string => {
-  if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M'
-  if (num >= 1000) return (num / 1000).toFixed(1) + 'K'
-  return num.toString()
-}
-
-const uniqueTypes = computed(() => {
-  const types = new Set(indexes.value.map(i => i.type))
-  return Array.from(types).filter(t => t !== 'unknown')
-})
-
-const getHealthColor = (health: string) => {
-  switch (health) {
-    case 'green': return 'text-emerald-400'
-    case 'yellow': return 'text-amber-400'
-    case 'red': return 'text-rose-400'
-    default: return 'text-slate-500'
-  }
-}
-
-const getHealthBg = (health: string) => {
-  switch (health) {
-    case 'green': return 'bg-emerald-500/20'
-    case 'yellow': return 'bg-amber-500/20'
-    case 'red': return 'bg-rose-500/20'
-    default: return 'bg-slate-500/20'
-  }
-}
-
-const getHealthGlow = (health: string) => {
-  switch (health) {
-    case 'green': return 'shadow-emerald-500/30'
-    case 'yellow': return 'shadow-amber-500/30'
-    case 'red': return 'shadow-rose-500/30'
-    default: return 'shadow-slate-500/30'
-  }
-}
-
-const viewIndex = (name: string) => router.push(`/intelligence/indexes/${name}`)
-
-const confirmDelete = (indexName: string) => {
-  indexToDelete.value = indexName
+function handleDeleteClick(index: Index) {
+  indexToDelete.value = index
   deleteError.value = null
   deleteModalOpen.value = true
 }
 
-const cancelDelete = () => {
+function cancelDelete() {
   deleteModalOpen.value = false
   indexToDelete.value = null
   deleteError.value = null
 }
 
-const deleteIndex = async () => {
+async function confirmDelete() {
   if (!indexToDelete.value) return
 
   try {
-    deleting.value = true
     deleteError.value = null
-    await indexManagerApi.indexes.delete(indexToDelete.value)
+    await indexes.deleteIndex(indexToDelete.value.name)
     deleteModalOpen.value = false
     indexToDelete.value = null
-    await loadIndexes()
-  } catch (err) {
-    console.error('Failed to delete index:', err)
+  } catch {
     deleteError.value = 'Failed to delete index. Please try again.'
-  } finally {
-    deleting.value = false
   }
 }
-
-onMounted(loadIndexes)
 </script>
 
 <template>
-  <div class="min-h-screen indexes-view">
+  <div class="min-h-screen">
     <!-- Header Section -->
-    <header class="mb-8">
+    <header class="mb-6">
       <div class="flex items-start justify-between">
         <div>
-          <div class="flex items-center gap-3 mb-2">
-            <div class="p-2 rounded-lg bg-gradient-to-br from-blue-500/20 to-cyan-500/20 border border-blue-500/30">
-              <Database class="h-6 w-6 text-blue-400" />
+          <div class="mb-2 flex items-center gap-3">
+            <div class="rounded-lg border bg-blue-500/10 p-2">
+              <Database class="h-6 w-6 text-blue-500" />
             </div>
-            <h1 class="text-2xl font-semibold tracking-tight text-foreground">
-              Index Observatory
+            <h1 class="text-2xl font-semibold tracking-tight">
+              Elasticsearch Indexes
             </h1>
           </div>
-          <p class="text-muted-foreground text-sm ml-[52px]">
+          <p class="ml-[52px] text-sm text-muted-foreground">
             Monitor and manage Elasticsearch indexes across your data pipeline
           </p>
         </div>
         <Button
           variant="outline"
           size="sm"
-          class="border-border/50 hover:border-blue-500/50 hover:bg-blue-500/10 transition-all duration-300"
-          :disabled="loading"
-          @click="loadIndexes"
+          :disabled="indexes.isLoading.value"
+          @click="indexes.refetch()"
         >
           <RefreshCw
             class="mr-2 h-4 w-4 transition-transform"
-            :class="{ 'animate-spin': loading }"
+            :class="{ 'animate-spin': indexes.isFetching.value }"
           />
           Refresh
         </Button>
@@ -224,240 +88,43 @@ onMounted(loadIndexes)
     </header>
 
     <!-- Stats Cards -->
-    <div
-      v-if="!loading && !error && indexes.length > 0"
-      class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8"
-    >
-      <div class="stat-card group">
-        <div class="flex items-center gap-3">
-          <div class="p-2 rounded-lg bg-blue-500/10 group-hover:bg-blue-500/20 transition-colors">
-            <Layers class="h-5 w-5 text-blue-400" />
-          </div>
-          <div>
-            <div class="text-2xl font-bold tabular-nums text-foreground">
-              {{ stats.total }}
-            </div>
-            <div class="text-xs text-muted-foreground uppercase tracking-wider">
-              Indexes
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="stat-card group">
-        <div class="flex items-center gap-3">
-          <div class="p-2 rounded-lg bg-violet-500/10 group-hover:bg-violet-500/20 transition-colors">
-            <FileText class="h-5 w-5 text-violet-400" />
-          </div>
-          <div>
-            <div class="text-2xl font-bold tabular-nums text-foreground">
-              {{ formatNumber(stats.totalDocs) }}
-            </div>
-            <div class="text-xs text-muted-foreground uppercase tracking-wider">
-              Documents
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="stat-card group">
-        <div class="flex items-center gap-3">
-          <div class="p-2 rounded-lg bg-cyan-500/10 group-hover:bg-cyan-500/20 transition-colors">
-            <HardDrive class="h-5 w-5 text-cyan-400" />
-          </div>
-          <div>
-            <div class="text-2xl font-bold tabular-nums text-foreground">
-              {{ formatSize(stats.totalSize) }}
-            </div>
-            <div class="text-xs text-muted-foreground uppercase tracking-wider">
-              Total Size
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="stat-card group">
-        <div class="flex items-center gap-3">
-          <div class="p-2 rounded-lg bg-emerald-500/10 group-hover:bg-emerald-500/20 transition-colors">
-            <Activity class="h-5 w-5 text-emerald-400" />
-          </div>
-          <div class="flex items-center gap-2">
-            <div class="flex items-center gap-1">
-              <span class="inline-block w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
-              <span class="text-sm font-semibold text-emerald-400">{{ stats.healthCounts.green }}</span>
-            </div>
-            <div class="flex items-center gap-1">
-              <span class="inline-block w-2 h-2 rounded-full bg-amber-400" />
-              <span class="text-sm font-semibold text-amber-400">{{ stats.healthCounts.yellow }}</span>
-            </div>
-            <div class="flex items-center gap-1">
-              <span class="inline-block w-2 h-2 rounded-full bg-rose-400" />
-              <span class="text-sm font-semibold text-rose-400">{{ stats.healthCounts.red }}</span>
-            </div>
-          </div>
-        </div>
-        <div class="text-xs text-muted-foreground uppercase tracking-wider mt-1 ml-[44px]">
-          Health Status
-        </div>
-      </div>
+    <div class="mb-6">
+      <IndexStatsCards
+        :stats="indexes.stats.value"
+        :loading="indexes.statsLoading.value"
+      />
     </div>
 
-    <!-- Search and Filter Bar -->
-    <div
-      v-if="!loading && !error && indexes.length > 0"
-      class="flex flex-col sm:flex-row gap-3 mb-6"
-    >
-      <div class="relative flex-1">
-        <Search class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          v-model="searchQuery"
-          type="text"
-          placeholder="Search indexes..."
-          class="pl-10 bg-card/50 border-border/50 focus:border-blue-500/50 focus:ring-blue-500/20"
-        />
-      </div>
-      <div class="flex gap-2">
-        <Button
-          v-for="type in ['all', ...uniqueTypes]"
-          :key="type"
-          size="sm"
-          :variant="(type === 'all' && !filterType) || filterType === type ? 'default' : 'outline'"
-          class="capitalize transition-all"
-          :class="{
-            'bg-blue-600 hover:bg-blue-700': (type === 'all' && !filterType) || filterType === type,
-            'border-border/50 hover:border-blue-500/30': !((type === 'all' && !filterType) || filterType === type)
-          }"
-          @click="filterType = type === 'all' ? null : type"
-        >
-          <Filter v-if="type !== 'all'" class="h-3 w-3 mr-1" />
-          {{ type === 'all' ? 'All Types' : type.replace(/_/g, ' ') }}
-        </Button>
-      </div>
-    </div>
-
-    <!-- Loading State -->
-    <div
-      v-if="loading"
-      class="flex flex-col items-center justify-center py-24"
-    >
-      <div class="relative">
-        <div class="absolute inset-0 rounded-full bg-blue-500/20 animate-ping" />
-        <Loader2 class="h-12 w-12 animate-spin text-blue-400 relative" />
-      </div>
-      <p class="mt-4 text-muted-foreground text-sm">Loading indexes...</p>
+    <!-- Filter Bar -->
+    <div class="mb-6">
+      <IndexesFilterBar />
     </div>
 
     <!-- Error State -->
     <div
-      v-else-if="error"
+      v-if="indexes.hasError.value"
       class="rounded-xl border border-rose-500/30 bg-rose-500/10 p-8 text-center"
     >
-      <AlertTriangle class="h-12 w-12 text-rose-400 mx-auto mb-4" />
-      <p class="text-rose-400 font-medium">{{ error }}</p>
+      <AlertTriangle class="mx-auto mb-4 h-12 w-12 text-rose-400" />
+      <p class="font-medium text-rose-400">
+        Unable to load Elasticsearch indexes.
+      </p>
       <Button
         variant="outline"
         size="sm"
         class="mt-4 border-rose-500/30 hover:bg-rose-500/10"
-        @click="loadIndexes"
+        @click="indexes.refetch()"
       >
         Try Again
       </Button>
     </div>
 
-    <!-- Empty State -->
-    <div
-      v-else-if="indexes.length === 0"
-      class="rounded-xl border border-border/50 bg-card/30 p-12 text-center"
-    >
-      <div class="inline-flex p-4 rounded-full bg-muted/50 mb-4">
-        <Database class="h-12 w-12 text-muted-foreground" />
-      </div>
-      <h3 class="text-lg font-medium text-foreground mb-2">No indexes found</h3>
-      <p class="text-muted-foreground text-sm max-w-md mx-auto">
-        Indexes will be created automatically when content is crawled and classified.
-      </p>
-    </div>
-
-    <!-- Index Grid -->
-    <div
-      v-else-if="filteredIndexes.length > 0"
-      class="grid gap-3"
-    >
-      <TransitionGroup name="list">
-        <div
-          v-for="(index, i) in filteredIndexes"
-          :key="index.name"
-          class="index-card group"
-          :style="{ animationDelay: `${i * 30}ms` }"
-          @click="viewIndex(index.name)"
-        >
-          <!-- Health Indicator -->
-          <div class="flex items-center gap-4 min-w-0">
-            <div
-              class="relative flex-shrink-0 w-3 h-3 rounded-full transition-all duration-300"
-              :class="[getHealthBg(index.health), getHealthColor(index.health)]"
-            >
-              <span
-                v-if="index.health === 'green'"
-                class="absolute inset-0 rounded-full animate-ping opacity-75"
-                :class="getHealthBg(index.health)"
-              />
-            </div>
-
-            <!-- Index Name -->
-            <div class="min-w-0 flex-1">
-              <h3 class="font-mono text-sm font-medium text-foreground truncate group-hover:text-blue-400 transition-colors">
-                {{ index.name }}
-              </h3>
-              <span class="text-xs text-muted-foreground capitalize">
-                {{ index.type.replace(/_/g, ' ') }}
-              </span>
-            </div>
-          </div>
-
-          <!-- Metrics -->
-          <div class="flex items-center gap-6">
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums text-foreground">
-                {{ index.document_count.toLocaleString() }}
-              </div>
-              <div class="text-xs text-muted-foreground">docs</div>
-            </div>
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums text-foreground">
-                {{ index.size }}
-              </div>
-              <div class="text-xs text-muted-foreground">size</div>
-            </div>
-            <div
-              class="px-2 py-1 rounded text-xs font-medium capitalize"
-              :class="[getHealthBg(index.health), getHealthColor(index.health)]"
-            >
-              {{ index.health }}
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              class="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-rose-500/10 hover:text-rose-400"
-              title="Delete index"
-              @click.stop="confirmDelete(index.name)"
-            >
-              <Trash2 class="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </TransitionGroup>
-    </div>
-
-    <!-- No Results -->
-    <div
-      v-else
-      class="rounded-xl border border-border/50 bg-card/30 p-8 text-center"
-    >
-      <Search class="h-8 w-8 text-muted-foreground mx-auto mb-3" />
-      <p class="text-muted-foreground text-sm">
-        No indexes match your search criteria
-      </p>
+    <!-- Table -->
+    <div v-else>
+      <IndexesTable
+        @view="handleView"
+        @delete="handleDeleteClick"
+      />
     </div>
 
     <!-- Delete Confirmation Modal -->
@@ -474,21 +141,21 @@ onMounted(loadIndexes)
           />
 
           <!-- Modal -->
-          <div class="modal-content relative z-10 w-full max-w-md">
+          <div class="relative z-10 w-full max-w-md rounded-2xl border bg-card shadow-xl">
             <div class="p-6">
               <div class="flex items-start gap-4">
-                <div class="flex-shrink-0 w-12 h-12 rounded-full bg-rose-500/10 flex items-center justify-center">
+                <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-rose-500/10">
                   <AlertTriangle class="h-6 w-6 text-rose-400" />
                 </div>
-                <div class="flex-1 min-w-0">
-                  <h3 class="text-lg font-semibold text-foreground mb-2">
+                <div class="min-w-0 flex-1">
+                  <h3 class="mb-2 text-lg font-semibold">
                     Delete Index
                   </h3>
-                  <p class="text-sm text-muted-foreground mb-2">
+                  <p class="mb-2 text-sm text-muted-foreground">
                     Are you sure you want to delete:
                   </p>
-                  <code class="block text-sm font-mono font-medium text-rose-400 bg-rose-500/10 px-3 py-2 rounded-lg mb-4 break-all">
-                    {{ indexToDelete }}
+                  <code class="mb-4 block break-all rounded-lg bg-rose-500/10 px-3 py-2 font-mono text-sm font-medium text-rose-400">
+                    {{ indexToDelete?.name }}
                   </code>
                   <p class="text-sm text-muted-foreground">
                     This action cannot be undone. All documents will be permanently deleted.
@@ -496,31 +163,29 @@ onMounted(loadIndexes)
 
                   <div
                     v-if="deleteError"
-                    class="mt-4 text-sm text-rose-400 bg-rose-500/10 px-3 py-2 rounded-lg"
+                    class="mt-4 rounded-lg bg-rose-500/10 px-3 py-2 text-sm text-rose-400"
                   >
                     {{ deleteError }}
                   </div>
 
-                  <div class="flex justify-end gap-3 mt-6">
+                  <div class="mt-6 flex justify-end gap-3">
                     <Button
                       variant="outline"
-                      :disabled="deleting"
-                      class="border-border/50"
+                      :disabled="indexes.isDeleting.value"
                       @click="cancelDelete"
                     >
                       Cancel
                     </Button>
                     <Button
                       variant="destructive"
-                      :disabled="deleting"
-                      class="bg-rose-600 hover:bg-rose-700"
-                      @click="deleteIndex"
+                      :disabled="indexes.isDeleting.value"
+                      @click="confirmDelete"
                     >
                       <Loader2
-                        v-if="deleting"
+                        v-if="indexes.isDeleting.value"
                         class="mr-2 h-4 w-4 animate-spin"
                       />
-                      {{ deleting ? 'Deleting...' : 'Delete Index' }}
+                      {{ indexes.isDeleting.value ? 'Deleting...' : 'Delete Index' }}
                     </Button>
                   </div>
                 </div>
@@ -534,81 +199,6 @@ onMounted(loadIndexes)
 </template>
 
 <style scoped>
-.indexes-view {
-  --card-glow: 0 0 0 1px rgba(59, 130, 246, 0);
-}
-
-.stat-card {
-  @apply relative p-4 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm;
-  @apply transition-all duration-300 ease-out;
-  @apply hover:border-blue-500/30 hover:bg-card/80;
-  box-shadow: var(--card-glow);
-}
-
-.stat-card:hover {
-  --card-glow: 0 0 20px -5px rgba(59, 130, 246, 0.15);
-}
-
-.index-card {
-  @apply relative flex items-center justify-between gap-4 p-4 rounded-xl;
-  @apply border border-border/50 bg-card/30 backdrop-blur-sm;
-  @apply cursor-pointer transition-all duration-200 ease-out;
-  @apply hover:border-blue-500/40 hover:bg-card/60;
-  animation: slideIn 0.3s ease-out backwards;
-}
-
-.index-card:hover {
-  box-shadow: 0 0 30px -10px rgba(59, 130, 246, 0.2);
-  transform: translateX(2px);
-}
-
-@keyframes slideIn {
-  from {
-    opacity: 0;
-    transform: translateX(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-.modal-content {
-  @apply rounded-2xl border border-border/50 bg-card backdrop-blur-xl;
-  box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.05),
-    0 25px 50px -12px rgba(0, 0, 0, 0.5),
-    0 0 100px -20px rgba(59, 130, 246, 0.2);
-  animation: modalIn 0.2s ease-out;
-}
-
-@keyframes modalIn {
-  from {
-    opacity: 0;
-    transform: scale(0.95) translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
-}
-
-/* List transitions */
-.list-enter-active,
-.list-leave-active {
-  transition: all 0.3s ease;
-}
-
-.list-enter-from {
-  opacity: 0;
-  transform: translateX(-20px);
-}
-
-.list-leave-to {
-  opacity: 0;
-  transform: translateX(20px);
-}
-
 /* Modal transitions */
 .modal-enter-active,
 .modal-leave-active {
@@ -618,10 +208,5 @@ onMounted(loadIndexes)
 .modal-enter-from,
 .modal-leave-to {
   opacity: 0;
-}
-
-.modal-enter-from .modal-content,
-.modal-leave-to .modal-content {
-  transform: scale(0.95) translateY(10px);
 }
 </style>

--- a/index-manager/internal/domain/index.go
+++ b/index-manager/internal/domain/index.go
@@ -60,3 +60,30 @@ type IndexStats struct {
 	ClusterHealth   string         `json:"cluster_health"`
 	IndexesByHealth map[string]int `json:"indexes_by_health"`
 }
+
+// ListIndicesRequest holds pagination, filtering, and sorting parameters
+type ListIndicesRequest struct {
+	// Existing filters
+	Type       string // IndexType filter
+	SourceName string // Source name filter
+
+	// New filters
+	Search string // Name search filter (case-insensitive substring)
+	Health string // Health filter (green, yellow, red)
+
+	// Pagination
+	Limit  int // Default: 50
+	Offset int // Default: 0
+
+	// Sorting
+	SortBy    string // name, document_count, size, health (default: name)
+	SortOrder string // asc, desc (default: asc)
+}
+
+// ListIndicesResponse represents paginated indices response
+type ListIndicesResponse struct {
+	Indices []*Index `json:"indices"`
+	Total   int      `json:"total"`
+	Limit   int      `json:"limit"`
+	Offset  int      `json:"offset"`
+}


### PR DESCRIPTION
## Summary

- Add server-side pagination, filtering, and sorting to the Elasticsearch Indexes page
- Backend changes to index-manager API (`GET /api/v1/indexes`)
- Frontend refactor following the Jobs pattern with reusable components

## Changes

### Backend (index-manager)
- New domain types: `ListIndicesRequest`, `ListIndicesResponse`
- Updated `ListIndices` handler and service to support:
  - Pagination: `limit`, `offset` query params
  - Sorting: `sortBy` (name, document_count, size, health, type), `sortOrder` (asc, desc)
  - Filtering: `search` (name substring), `health` (green, yellow, red)
- Response now includes `total`, `limit`, `offset` for frontend pagination

### Frontend (dashboard)
- New feature module: `/features/intelligence/`
  - `useIndexes` composable wrapping `useServerPaginatedTable`
  - `IndexesFilterBar` - search input, type dropdown, health filter pills
  - `IndexesTable` - sortable columns, pagination controls
  - `IndexStatsCards` - summary statistics cards
- Refactored `IndexesView` to use new components
- Updated API client types for pagination support

## Test plan

- [ ] Visit `/dashboard/intelligence/indexes`
- [ ] Verify pagination controls appear at bottom
- [ ] Test page navigation (next/prev, page numbers)
- [ ] Test page size selector (10, 25, 50, 100)
- [ ] Test sorting by clicking column headers
- [ ] Test search filter (type in search box)
- [ ] Test type filter dropdown
- [ ] Test health filter pills
- [ ] Test clear filters button
- [ ] Test delete index action

🤖 Generated with [Claude Code](https://claude.com/claude-code)