### PR TITLE
feat(classifier): declarative routing and sidecar registry

### DIFF
--- a/classifier/internal/bootstrap/classifier.go
+++ b/classifier/internal/bootstrap/classifier.go
@@ -44,6 +44,11 @@ type HTTPComponents struct {
 
 // NewHTTPComponents creates all components for the HTTP server.
 func NewHTTPComponents(cfg *config.Config, logger infralogger.Logger) (*HTTPComponents, error) {
+	if cfg.Classification.SidecarRegistryFromYAML {
+		logger.Warn("classification.sidecar_registry is set in config but is not yet consumed; " +
+			"use the named fields (crime.enabled, mining.enabled, etc.) to control sidecar behaviour")
+	}
+
 	// Setup database
 	dbComps, err := SetupDatabase(cfg, logger)
 	if err != nil {

--- a/classifier/internal/classifier/observability.go
+++ b/classifier/internal/classifier/observability.go
@@ -82,11 +82,13 @@ func (c *Classifier) logSidecarError(
 	)
 }
 
-// logSidecarNilResult emits a structured Warn log when an ML sidecar returns a nil result with no error.
+// logSidecarNilResult emits a structured Error log when an ML sidecar returns a nil result with no error.
+// A nil result without an error is a contract violation in the sidecar interface and indicates a client bug.
 func (c *Classifier) logSidecarNilResult(sidecar, contentID string, latencyMs int64) {
-	c.logger.Warn("ML sidecar returned nil result without error",
+	c.logger.Error("ML sidecar returned nil result without error",
 		infralogger.String("sidecar", sidecar),
 		infralogger.String("content_id", contentID),
 		infralogger.Int64("latency_ms", latencyMs),
+		infralogger.String("outcome", "nil_result"),
 	)
 }

--- a/docs/plans/2026-02-20-fix-pr-91-review-issues.md
+++ b/docs/plans/2026-02-20-fix-pr-91-review-issues.md
@@ -2,757 +2,443 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Fix all critical and important issues found in the PR #91 code review, plus implement all "nice to have" improvements.
+**Goal:** Fix all critical, important, and suggestion-level issues identified in the PR #91 review for the classifier declarative routing feature.
 
-**Architecture:** All changes are in the classifier service. The fixes fall into four categories: test correctness (`classifier_routing_test.go`), silent-failure logging (`classifier.go`), processor wiring parity (`cmd/processor/processor.go`), and dead-code documentation (`config/config.go`). No new packages or interfaces are needed.
+**Architecture:** All changes are confined to the classifier service. No API or schema changes. Changes fall into three categories: observability/logging correctness, startup validation hardening, and test coverage for the new routing dispatch.
 
-**Tech Stack:** Go 1.26, golangci-lint, `task test:classifier`, `task lint:classifier`
-
----
-
-## Task 1: Fix `t.Helper()` misuse in top-level test functions
-
-**Files:**
-- Modify: `classifier/internal/classifier/classifier_routing_test.go:14,52,80`
-
-**Step 1: Remove `t.Helper()` from the two top-level test functions**
-
-The lines `t.Helper()` at line 14 (inside `TestResolveSidecars`) and line 80 (inside `TestResolveSidecars_MissingKey_ReturnsNilAndLogs`) are wrong — `t.Helper()` is for helper functions only, not `Test*` entry points. Also remove it from the subtest closure at line 52 — subtests registered via `t.Run` are also not helpers.
-
-In `classifier/internal/classifier/classifier_routing_test.go`, make these changes:
-
-```go
-// Line 13-14: remove t.Helper()
-func TestResolveSidecars(t *testing.T) {
-    // (no t.Helper() here)
-    routingTable := ...
-```
-
-```go
-// Line 51-52: remove t.Helper() from t.Run closure
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            // (no t.Helper() here)
-            got := clf.ResolveSidecars(tt.contentType, tt.subtype)
-```
-
-```go
-// Line 79-80: remove t.Helper()
-func TestResolveSidecars_MissingKey_ReturnsNilAndLogs(t *testing.T) {
-    // (no t.Helper() here)
-    cfg := Config{
-```
-
-**Step 2: Run tests to confirm they still pass**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier
-```
-
-Expected: all tests pass.
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/classifier/classifier_routing_test.go
-git commit -m "test(classifier): remove t.Helper() from top-level test functions"
-```
+**Tech Stack:** Go 1.26+, golangci-lint, `task` taskfile runner
 
 ---
 
-## Task 2: Fix `assertEqualStringSlices` to distinguish nil from empty slice
+## Task 1: Harden startup validation — unknown sidecar names
 
 **Files:**
-- Modify: `classifier/internal/classifier/classifier_routing_test.go:47-48,59-76`
+- Modify: `classifier/internal/classifier/classifier.go:72-80`
+- Modify: `classifier/internal/classifier/classifier_routing_test.go`
 
-**Background:** `append([]string(nil), []string{}...)` returns `nil` in Go. So routing entries with empty slice values (`"article:report": {}`) produce a `nil` return from `ResolveSidecars`, not `[]string{}`. The test cases for `"article report"` and `"page has explicit empty routing"` claimed to expect `[]string{}` but the helper couldn't distinguish nil from empty — both have length 0.
+**Step 1: Add unknown-name check to startup loop**
 
-The semantics matter: `nil` means "no routing entry found, log and skip" whereas `[]string{}` means "explicit entry found, explicitly empty list". We fix both the helper and the test expectations.
-
-**Step 1: Update `assertEqualStringSlices` to check nil/non-nil distinction**
-
-Replace the body of `assertEqualStringSlices` with:
+In `NewClassifier`, change the existing loop at lines 72-80 from checking only `known && !enabled` to also check `!known`:
 
 ```go
-func assertEqualStringSlices(t *testing.T, got, want []string) {
-    t.Helper()
-    if (got == nil) != (want == nil) {
-        t.Errorf("ResolveSidecars() nil mismatch: got nil=%v, want nil=%v; got=%v, want=%v",
-            got == nil, want == nil, got, want)
-        return
-    }
-    if want == nil {
-        return
-    }
-    if len(got) != len(want) {
-        t.Errorf("ResolveSidecars() length = %d, want %d; got %v", len(got), len(want), got)
-        return
-    }
-    for i := range got {
-        if got[i] != want[i] {
-            t.Errorf("ResolveSidecars()[%d] = %q, want %q", i, got[i], want[i])
+for routeKey, names := range routingTable {
+    for _, name := range names {
+        switch enabled, known := sidecarEnabled[name]; {
+        case !known:
+            logger.Warn("Routing table references unknown sidecar name; it will always be ignored",
+                infralogger.String("routing_key", routeKey),
+                infralogger.String("sidecar_name", name),
+            )
+        case known && !enabled:
+            logger.Warn("Routing table references disabled sidecar classifier",
+                infralogger.String("routing_key", routeKey),
+                infralogger.String("sidecar_name", name),
+            )
         }
     }
 }
 ```
 
-**Step 2: Update test cases that expect `[]string{}` to expect `nil`**
+**Step 2: Add recording logger to test file**
 
-In the `tests` table in `TestResolveSidecars`, change:
+Add `recordingLogger` type in `classifier_routing_test.go` that captures Warn calls:
+
 ```go
-// Before:
-{"article report", domain.ContentTypeArticle, domain.ContentSubtypeReport, []string{}},
-{"page has explicit empty routing", domain.ContentTypePage, "", []string{}},
+type recordingLogger struct {
+    mockLogger
+    warns []string
+}
 
-// After:
-{"article report", domain.ContentTypeArticle, domain.ContentSubtypeReport, nil},
-{"page has explicit empty routing", domain.ContentTypePage, "", nil},
+func (r *recordingLogger) Warn(msg string, _ ...infralogger.Field) {
+    r.warns = append(r.warns, msg)
+}
+
+func (r *recordingLogger) With(_ ...infralogger.Field) infralogger.Logger { return r }
 ```
 
-**Step 3: Run tests to confirm they pass**
+**Step 3: Add test for unknown sidecar warning**
 
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier
+```go
+func TestNewClassifier_UnknownSidecarInRoutingTable_Warns(t *testing.T) {
+    rec := &recordingLogger{}
+    cfg := Config{
+        RoutingTable: map[string][]string{
+            "article": {"crime", "typo_sidecar"},
+        },
+    }
+    NewClassifier(rec, []domain.ClassificationRule{}, testhelpers.NewMockSourceReputationDB(), cfg)
+    if len(rec.warns) == 0 {
+        t.Fatal("expected a Warn for unknown sidecar name, got none")
+    }
+    found := false
+    for _, w := range rec.warns {
+        if strings.Contains(w, "unknown sidecar name") {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Errorf("expected warn containing 'unknown sidecar name', got: %v", rec.warns)
+    }
+}
 ```
 
-Expected: all tests pass.
+**Step 4: Add test for disabled-sidecar warning (and verify no warn for enabled)**
 
-**Step 4: Commit**
+```go
+func TestNewClassifier_DisabledSidecarInRoutingTable_Warns(t *testing.T) {
+    rec := &recordingLogger{}
+    cfg := Config{
+        CrimeClassifier: nil, // disabled
+        RoutingTable: map[string][]string{
+            "article": {"crime"},
+        },
+    }
+    NewClassifier(rec, []domain.ClassificationRule{}, testhelpers.NewMockSourceReputationDB(), cfg)
+    found := false
+    for _, w := range rec.warns {
+        if strings.Contains(w, "disabled sidecar") {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Errorf("expected warn containing 'disabled sidecar', got: %v", rec.warns)
+    }
+}
+```
 
+**Step 5: Run tests**
 ```bash
-git add classifier/internal/classifier/classifier_routing_test.go
-git commit -m "test(classifier): fix nil-vs-empty slice distinction in assertEqualStringSlices"
+cd classifier && go test ./internal/classifier/... -run TestNewClassifier -v
 ```
 
 ---
 
-## Task 3: Add missing test — article subtype fallback to "article" key
+## Task 2: Fix logSidecarNilResult severity
+
+**Files:**
+- Modify: `classifier/internal/classifier/observability.go:86-92`
+
+**Step 1: Change Warn to Error and add outcome field**
+
+```go
+func (c *Classifier) logSidecarNilResult(sidecar, contentID string, latencyMs int64) {
+    c.logger.Error("ML sidecar returned nil result without error",
+        infralogger.String("sidecar", sidecar),
+        infralogger.String("content_id", contentID),
+        infralogger.Int64("latency_ms", latencyMs),
+        infralogger.String("outcome", "nil_result"),
+    )
+}
+```
+
+**Step 2: Run tests**
+```bash
+cd classifier && go test ./internal/classifier/... -v
+```
+
+---
+
+## Task 3: Fix runLocationOptional placeholder log
+
+**Files:**
+- Modify: `classifier/internal/classifier/classifier.go:433-435`
+
+**Step 1: Replace logSidecarSuccess call with location-specific log**
+
+Replace:
+```go
+c.logSidecarSuccess("location", raw, "",
+    "", 0, 0, "", "", latencyMs, 0, "")
+```
+
+With:
+```go
+c.logger.Info("Location classification complete",
+    infralogger.String("sidecar", "location"),
+    infralogger.String("content_id", raw.ID),
+    infralogger.String("source", raw.SourceName),
+    infralogger.String("title_excerpt", truncateWords(raw.Title, titleExcerptWordLimit)),
+    infralogger.String("specificity", locResult.Specificity),
+    infralogger.String("city", locResult.City),
+    infralogger.String("province", locResult.Province),
+    infralogger.String("country", locResult.Country),
+    infralogger.Float64("confidence", locResult.Confidence),
+    infralogger.Int64("latency_ms", latencyMs),
+    infralogger.String("outcome", "success"),
+)
+```
+
+**Step 2: Run tests**
+```bash
+cd classifier && go test ./internal/classifier/... -v
+```
+
+---
+
+## Task 4: Raise ResolveSidecars subtype fallback from Debug to Warn
+
+**Files:**
+- Modify: `classifier/internal/classifier/classifier.go:109-112`
+
+**Step 1: Change Debug to Warn with updated message**
+
+```go
+c.logger.Warn("No routing entry for article subtype; falling back to article route — all sidecars will run",
+    infralogger.String("content_subtype", subtype),
+    infralogger.String("fallback_key", "article"),
+)
+```
+
+---
+
+## Task 5: Export SetDefaults from config package and fix processor fallback
+
+**Files:**
+- Modify: `classifier/internal/config/config.go`
+- Modify: `classifier/cmd/processor/processor.go:60-78`
+
+**Step 1: Export SetDefaults in config.go**
+
+Add after `setDefaults`:
+```go
+// SetDefaults applies all defaults to cfg. Call this when constructing a Config without Load.
+func SetDefaults(cfg *Config) {
+    setDefaults(cfg)
+}
+```
+
+**Step 2: Add defaultProcessorConcurrency constant to processor.go**
+
+```go
+defaultProcessorConcurrency = 5
+```
+
+**Step 3: Fix LoadConfig fallback to call SetDefaults**
+
+Replace:
+```go
+cfg = &config.Config{}
+if cfg.Service.PollInterval == 0 {
+    cfg.Service.PollInterval = defaultPollInterval
+}
+if cfg.Service.BatchSize == 0 {
+    cfg.Service.BatchSize = 100
+}
+if cfg.Service.Concurrency == 0 {
+    cfg.Service.Concurrency = 5
+}
+```
+
+With:
+```go
+cfg = &config.Config{}
+config.SetDefaults(cfg)
+cfg.Service.Concurrency = defaultProcessorConcurrency // processor uses lower concurrency than HTTP service
+```
+
+**Step 4: Run tests**
+```bash
+cd classifier && go test ./... -v
+```
+
+---
+
+## Task 6: Add rules-only mode warning to all processor classifier factories
+
+**Files:**
+- Modify: `classifier/cmd/processor/processor.go:217-299`
+
+**Step 1: Update all 5 factories**
+
+Apply the bootstrap pattern (warn when enabled but URL empty) to:
+- `createCrimeClassifier`
+- `createMiningClassifier`
+- `createCoforgeClassifier`
+- `createEntertainmentClassifier`
+- `createAnishinaabeClassifier`
+
+Pattern for each:
+```go
+if cfg.Classification.Crime.MLServiceURL != "" {
+    mlClient = mlclient.NewClient(cfg.Classification.Crime.MLServiceURL)
+    log.Info("Crime classifier enabled for processor",
+        infralogger.String("ml_service_url", cfg.Classification.Crime.MLServiceURL))
+} else {
+    log.Warn("Crime classifier enabled for processor but ML service URL is empty; running in rules-only mode",
+        infralogger.String("ml_service_url", ""))
+}
+```
+
+---
+
+## Task 7: SidecarRegistry YAML warning
+
+**Files:**
+- Modify: `classifier/internal/config/config.go`
+- Modify: `classifier/internal/bootstrap/classifier.go`
+- Modify: `classifier/cmd/processor/processor.go`
+
+**Step 1: Add SidecarRegistryFromYAML flag to ClassificationConfig**
+
+```go
+// SidecarRegistryFromYAML is true when sidecar_registry was set explicitly in the YAML config.
+// It has no effect on runtime behavior (SidecarRegistry is not yet consumed) but triggers a
+// startup warning so operators know the field is inoperative.
+SidecarRegistryFromYAML bool `yaml:"-"` // not loaded from YAML; set by setClassificationDefaults
+```
+
+**Step 2: Set the flag in setClassificationDefaults**
+
+```go
+if c.SidecarRegistry != nil {
+    c.SidecarRegistryFromYAML = true
+} else {
+    c.SidecarRegistry = getDefaultSidecarRegistry(c)
+}
+```
+
+**Step 3: Warn in bootstrap NewHTTPComponents**
+
+After the call to `SetupDatabase` (first thing that needs logger), add:
+```go
+if cfg.Classification.SidecarRegistryFromYAML {
+    logger.Warn("classification.sidecar_registry is set in config but is not yet consumed; " +
+        "use the named fields (crime.enabled, mining.enabled, etc.) to control sidecar behaviour")
+}
+```
+
+**Step 4: Warn in processor createClassifierConfig**
+
+At the top of `createClassifierConfig`:
+```go
+if cfg.Classification.SidecarRegistryFromYAML {
+    log.Warn("classification.sidecar_registry is set in config but is not yet consumed; " +
+        "use the named fields (crime.enabled, mining.enabled, etc.) to control sidecar behaviour")
+}
+```
+
+---
+
+## Task 8: Add tests for runOptionalClassifiers dispatch
 
 **Files:**
 - Modify: `classifier/internal/classifier/classifier_routing_test.go`
 
-**Background:** `ResolveSidecars("article", "press_release")` when `"article:press_release"` is not in the routing table should fall back to the `"article"` key. The current tests never exercise this branch (the `"article default"` test uses `subtype=""` which takes the `else` branch directly).
+**Step 1: Add mock classifiers for testing dispatch**
 
-**Step 1: Add the fallback test case to the table in `TestResolveSidecars`**
+Create minimal mock crime/location classifiers that record calls:
+```go
+type mockCrimeClassifier struct {
+    called bool
+}
+func (m *mockCrimeClassifier) Classify(_ context.Context, _ *domain.RawContent) (*CrimeResult, error) {
+    m.called = true
+    return &CrimeResult{Relevance: "not_crime"}, nil
+}
+```
 
-Add this case to the `tests` slice (after the existing "article blotter" case):
+**Step 2: Test nil-guard (disabled sidecar in routing table does not panic)**
 
 ```go
-{
-    "article unknown subtype falls back to article",
-    domain.ContentTypeArticle,
-    "press_release", // not in routing table as "article:press_release"
-    []string{"crime", "mining", "location"}, // same as "article"
-},
+func TestRunOptionalClassifiers_NilSidecarDoesNotPanic(t *testing.T) {
+    cfg := Config{
+        CrimeClassifier: nil,
+        RoutingTable: map[string][]string{"article": {"crime"}},
+    }
+    clf := NewClassifier(&mockLogger{}, nil, testhelpers.NewMockSourceReputationDB(), cfg)
+    raw := &domain.RawContent{ID: "test-1", Title: "Test"}
+    crime, _, _, _, _, _ := clf.classifyOptionalForPublishable(context.Background(), raw, "article", "")
+    if crime != nil {
+        t.Error("expected nil crime result when classifier is nil")
+    }
+}
 ```
 
-The routing table used in `TestResolveSidecars` has `"article": {"crime", "mining", "location"}` but no `"article:press_release"` entry, so this correctly exercises the fallback path.
+**Step 3: Test unknown sidecar name does not panic**
 
-**Step 2: Run tests**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier
+```go
+func TestRunOptionalClassifiers_UnknownSidecarDoesNotPanic(t *testing.T) {
+    cfg := Config{
+        RoutingTable: map[string][]string{"article": {"unknown_future_sidecar"}},
+    }
+    clf := NewClassifier(&mockLogger{}, nil, testhelpers.NewMockSourceReputationDB(), cfg)
+    raw := &domain.RawContent{ID: "test-1", Title: "Test"}
+    // Should not panic
+    clf.classifyOptionalForPublishable(context.Background(), raw, "article", "")
+}
 ```
 
-Expected: all tests pass, including the new case.
+**Step 4: Test enabled sidecar in routing table IS called**
 
-**Step 3: Commit**
+```go
+func TestRunOptionalClassifiers_EnabledSidecarIsCalled(t *testing.T) {
+    mock := &mockCrimeClassifier{}
+    crimeCC := &CrimeClassifier{ /* use constructor or test helper */ }
+    // ... wire mock into CrimeClassifier and verify mock.called == true
+}
+```
 
+Note: If `CrimeClassifier` doesn't expose the ML client for testing, test via `Classify()` output instead.
+
+**Step 5: Run tests**
 ```bash
-git add classifier/internal/classifier/classifier_routing_test.go
-git commit -m "test(classifier): add article subtype fallback test case for ResolveSidecars"
+cd classifier && go test ./internal/classifier/... -v
 ```
 
 ---
 
-## Task 4: Add subtype-fallback debug log in `ResolveSidecars`
+## Task 9: Fix ClassifyBatch to log failure summary
 
 **Files:**
-- Modify: `classifier/internal/classifier/classifier.go:83-103`
+- Modify: `classifier/internal/classifier/classifier.go:219-238`
 
-**Background:** When an article has a non-empty subtype that is not in the routing table, the code silently falls back to the `"article"` key with no log. An operator adding a new content subtype without a routing entry has no observability into which route was used.
-
-**Step 1: Add a Debug log for the subtype miss before the fallback**
-
-Current code (lines 83-103):
-```go
-func (c *Classifier) ResolveSidecars(contentType, subtype string) []string {
-    var key string
-    if contentType == domain.ContentTypeArticle && subtype != "" {
-        key = "article:" + subtype
-        if names, ok := c.routingTable[key]; ok {
-            return names
-        }
-        key = "article"
-    } else {
-        key = contentType
-    }
-    ...
-}
-```
-
-Replace with:
-```go
-func (c *Classifier) ResolveSidecars(contentType, subtype string) []string {
-    var key string
-    if contentType == domain.ContentTypeArticle && subtype != "" {
-        key = "article:" + subtype
-        if names, ok := c.routingTable[key]; ok {
-            return names
-        }
-        c.logger.Debug("No routing entry for article subtype; falling back to article key",
-            infralogger.String("content_subtype", subtype),
-            infralogger.String("fallback_key", "article"),
-        )
-        key = "article"
-    } else {
-        key = contentType
-    }
-    if names, ok := c.routingTable[key]; ok {
-        return names
-    }
-    c.logger.Debug("No routing entry for content type; skipping optional classifiers",
-        infralogger.String("content_type", contentType),
-        infralogger.String("content_subtype", subtype),
-        infralogger.String("routing_key", key),
-    )
-    return nil
-}
-```
-
-**Step 2: Run tests and lint**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier && task lint:classifier
-```
-
-Expected: all pass.
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/classifier/classifier.go
-git commit -m "feat(classifier): log subtype fallback in ResolveSidecars for observability"
-```
-
----
-
-## Task 5: Warn on unknown sidecar names in `runOptionalClassifiers`
-
-**Files:**
-- Modify: `classifier/internal/classifier/classifier.go:243-260`
-
-**Background:** If the routing table contains `"crme"` (typo for `"crime"`), `allowed["crime"]` is false and the crime sidecar silently doesn't run. There is no log output.
-
-**Step 1: Add a named constant set and a warn loop**
-
-At the top of the file (near the existing constants block at line 12), add:
+**Step 1: Add failure counter and summary log**
 
 ```go
-// knownSidecarNames is the set of sidecar names recognised by runOptionalClassifiers.
-// Any name in the routing table not in this set is silently ignored but will emit a Warn log.
-var knownSidecarNames = map[string]bool{
-    "crime": true, "mining": true, "coforge": true,
-    "entertainment": true, "anishinaabe": true, "location": true,
-}
-```
+func (c *Classifier) ClassifyBatch(ctx context.Context, rawItems []*domain.RawContent) ([]*domain.ClassificationResult, error) {
+    results := make([]*domain.ClassificationResult, len(rawItems))
+    failedCount := 0
 
-Then in `runOptionalClassifiers`, after building the `allowed` map, add the warning loop:
-
-```go
-func (c *Classifier) runOptionalClassifiers(
-    ctx context.Context, raw *domain.RawContent, contentType string, sidecars []string,
-) (*domain.CrimeResult, *domain.MiningResult, *domain.CoforgeResult, *domain.EntertainmentResult, *domain.AnishinaabeResult, *domain.LocationResult) {
-    allowed := make(map[string]bool)
-    for _, name := range sidecars {
-        allowed[name] = true
-        if !knownSidecarNames[name] {
-            c.logger.Warn("Routing table contains unknown sidecar name; it will be ignored",
-                infralogger.String("sidecar_name", name),
-                infralogger.String("content_type", contentType),
+    for i, raw := range rawItems {
+        result, err := c.Classify(ctx, raw)
+        if err != nil {
+            c.logger.Error("Batch classification failed for item",
+                infralogger.Int("index", i),
                 infralogger.String("content_id", raw.ID),
+                infralogger.Error(err),
             )
+            failedCount++
+            continue
         }
+        results[i] = result
     }
-    return c.runCrimeOptional(ctx, raw, contentType, allowed["crime"]),
-        c.runMiningOptional(ctx, raw, contentType, allowed["mining"]),
-        c.runCoforgeOptional(ctx, raw, contentType, allowed["coforge"]),
-        c.runEntertainmentOptional(ctx, raw, contentType, allowed["entertainment"]),
-        c.runAnishinaabeOptional(ctx, raw, contentType, allowed["anishinaabe"]),
-        c.runLocationOptional(ctx, raw, allowed["location"])
-}
-```
 
-Note: the warning is emitted at classification time, not startup time, because the routing table is populated at startup and the classifier doesn't have logger context until it processes an item. This is a reasonable trade-off.
-
-**Step 2: Run tests and lint**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier && task lint:classifier
-```
-
-Expected: all pass. The linter may flag the `var` block as a package-level variable — if so, convert to a package-level function or use a local map literal inside the function (latter avoids linter issues with global state).
-
-If the linter objects to the `var knownSidecarNames` global, move it inside `runOptionalClassifiers` as a local map:
-
-```go
-knownSidecarNames := map[string]bool{
-    "crime": true, "mining": true, "coforge": true,
-    "entertainment": true, "anishinaabe": true, "location": true,
-}
-```
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/classifier/classifier.go
-git commit -m "feat(classifier): warn on unknown sidecar names in routing table"
-```
-
----
-
-## Task 6: Add nil-result warn log for mining/coforge/entertainment/anishinaabe helpers
-
-**Files:**
-- Modify: `classifier/internal/classifier/classifier.go:286-372`
-
-**Background:** Each of the four ML sidecar helpers (`runMiningOptional`, `runCoforgeOptional`, `runEntertainmentOptional`, `runAnishinaabeOptional`) has the pattern:
-
-```go
-if result != nil {
-    logSidecarSuccess(...)
-}
-return result // returns nil with zero log when result is nil and no error
-```
-
-This silently drops the result when a classifier returns `(nil, nil)`. While currently unreachable, it should emit a Warn to make future regressions visible.
-
-**Step 1: Fix all four helpers — change `if result != nil { log }; return result` to explicit nil guard with Warn**
-
-For `runMiningOptional` (lines 299-305), replace:
-```go
-    if minResult != nil {
-        c.logSidecarSuccess("mining-ml", raw, contentType,
-            minResult.Relevance, minResult.FinalConfidence,
-            minResult.MLConfidenceRaw, minResult.RuleTriggered,
-            minResult.DecisionPath, latencyMs, minResult.ProcessingTimeMs, minResult.ModelVersion)
-    }
-    return minResult
-```
-with:
-```go
-    if minResult == nil {
-        c.logger.Warn("Mining sidecar returned nil result without error",
-            infralogger.String("sidecar", "mining-ml"),
-            infralogger.String("content_id", raw.ID),
-            infralogger.Int64("latency_ms", latencyMs),
+    if failedCount > 0 {
+        c.logger.Error("Batch classification completed with failures",
+            infralogger.Int("total", len(rawItems)),
+            infralogger.Int("failed", failedCount),
+            infralogger.Int("succeeded", len(rawItems)-failedCount),
         )
-        return nil
     }
-    c.logSidecarSuccess("mining-ml", raw, contentType,
-        minResult.Relevance, minResult.FinalConfidence,
-        minResult.MLConfidenceRaw, minResult.RuleTriggered,
-        minResult.DecisionPath, latencyMs, minResult.ProcessingTimeMs, minResult.ModelVersion)
-    return minResult
-```
 
-Apply the same pattern for `runCoforgeOptional` (`cfResult`/`"coforge-ml"`), `runEntertainmentOptional` (`entResult`/`"entertainment-ml"`), and `runAnishinaabeOptional` (`aResult`/`"anishinaabe-ml"`).
-
-Also fix `runCrimeOptional` (lines 275-276) which silently returns nil when `scResult == nil`:
-```go
-    // Before:
-    if scResult == nil {
-        return nil
-    }
-    // After:
-    if scResult == nil {
-        c.logger.Warn("Crime sidecar returned nil result without error",
-            infralogger.String("sidecar", "crime-ml"),
-            infralogger.String("content_id", raw.ID),
-            infralogger.Int64("latency_ms", latencyMs),
-        )
-        return nil
-    }
-```
-
-**Step 2: Run tests and lint**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier && task lint:classifier
-```
-
-Expected: all pass.
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/classifier/classifier.go
-git commit -m "feat(classifier): warn when ML sidecar returns nil result without error"
+    return results, nil
+}
 ```
 
 ---
 
-## Task 7: Fix `runLocationOptional` — add latency, success log, consistent error log
+## Task 10: Lint and CI
 
-**Files:**
-- Modify: `classifier/internal/classifier/classifier.go:374-388`
-
-**Background:** Location is the only sidecar helper with no latency measurement, no success log, and a hand-written error log missing 7 structured fields. This means location errors/successes are invisible in dashboards.
-
-Location's `LocationResult` doesn't have `Relevance`, `FinalConfidence`, `MLConfidenceRaw`, `RuleTriggered`, `DecisionPath`, `ProcessingTimeMs`, `ModelVersion` fields that other sidecar results expose. We'll use empty/zero values for those `logSidecarSuccess` parameters.
-
-**Step 1: Add latency, logSidecarError, logSidecarSuccess to `runLocationOptional`**
-
-Replace the entire `runLocationOptional` function:
-
-```go
-func (c *Classifier) runLocationOptional(
-    ctx context.Context, raw *domain.RawContent, run bool,
-) *domain.LocationResult {
-    if !run || c.location == nil {
-        return nil
-    }
-    start := time.Now()
-    locResult, locErr := c.location.Classify(ctx, raw)
-    latencyMs := time.Since(start).Milliseconds()
-    if locErr != nil {
-        c.logSidecarError("location", raw, "", locErr, latencyMs)
-        return nil
-    }
-    if locResult == nil {
-        c.logger.Warn("Location sidecar returned nil result without error",
-            infralogger.String("sidecar", "location"),
-            infralogger.String("content_id", raw.ID),
-            infralogger.Int64("latency_ms", latencyMs),
-        )
-        return nil
-    }
-    c.logSidecarSuccess("location", raw, "",
-        "", 0, 0, "", "", latencyMs, 0, "")
-    return locResult
-}
-```
-
-Note: `contentType` is passed as `""` because `runLocationOptional` doesn't receive it (location is content-type-agnostic). This is consistent — the field will be empty in logs for location, which is accurate.
-
-**Step 2: Run tests and lint**
-
+**Step 1: Run linter**
 ```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier && task lint:classifier
+task lint:classifier
 ```
 
-Expected: all pass.
-
-**Step 3: Commit**
-
+**Step 2: Run full CI**
 ```bash
-git add classifier/internal/classifier/classifier.go
-git commit -m "feat(classifier): add latency measurement and consistent logging to runLocationOptional"
+task ci
 ```
 
----
-
-## Task 8: Add TODO comment to dead `SidecarRegistry` field in config
-
-**Files:**
-- Modify: `classifier/internal/config/config.go:140-141`
-
-**Background:** `SidecarRegistry` is populated by defaults but never read by bootstrap or classifier. Removing it now would break future work that intends to use it. Instead, add a clear comment so the next developer isn't confused.
-
-**Step 1: Update the comment on `SidecarRegistry`**
-
-Change:
-```go
-    // SidecarRegistry maps sidecar name (e.g. "crime", "mining") to enabled + URL. Optional; built from Crime/Mining/... if absent.
-    SidecarRegistry map[string]SidecarConfig `yaml:"sidecar_registry"`
-```
-
-To:
-```go
-    // SidecarRegistry maps sidecar name (e.g. "crime", "mining") to enabled + URL.
-    // Built from Crime/Mining/... named configs when absent in YAML.
-    // NOTE: Currently populated by setClassificationDefaults but not yet consumed by the bootstrap
-    // or classifier — the named fields (Crime, Mining, etc.) remain authoritative.
-    // TODO: when declarative registry-driven dispatch is implemented, this will replace named fields.
-    SidecarRegistry map[string]SidecarConfig `yaml:"sidecar_registry"`
-```
-
-**Step 2: Run lint**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task lint:classifier
-```
-
-Expected: passes.
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/config/config.go
-git commit -m "docs(classifier): clarify SidecarRegistry is populated but not yet consumed"
-```
-
----
-
-## Task 9: Fix processor `createClassifierConfig` — wire mining/coforge/entertainment/anishinaabe
-
-**Files:**
-- Modify: `classifier/cmd/processor/processor.go:1-30,182-230`
-
-**Background:** The processor path only wires `CrimeClassifier`. The bootstrap path wires all five sidecars. This means with `MINING_ENABLED=true`, the processor path still passes `nil` for `MiningClassifier` — the routing table may list `"mining"`, `run=true`, but `c.mining == nil` silently skips it.
-
-**Step 1: Add missing imports to processor.go**
-
-The processor currently imports only `mlclient`. Add the other four ML clients:
-
-```go
-import (
-    // ... existing imports ...
-    "github.com/jonesrussell/north-cloud/classifier/internal/miningmlclient"
-    "github.com/jonesrussell/north-cloud/classifier/internal/coforgemlclient"
-    "github.com/jonesrussell/north-cloud/classifier/internal/entertainmentmlclient"
-    "github.com/jonesrussell/north-cloud/classifier/internal/anishinaabemlclient"
-)
-```
-
-**Step 2: Add missing constants**
-
-The processor has `defaultMinQualityScore = 30` but bootstrap uses separate constants per-classifier. Since processor uses a single quality weight for all four, no new constants are needed — existing `defaultQualityWeight` applies.
-
-**Step 3: Update `createClassifierConfig` to wire all five sidecars**
-
-Replace the current `createClassifierConfig` in `processor.go`:
-
-```go
-func createClassifierConfig(cfg *config.Config, log infralogger.Logger) classifier.Config {
-    return classifier.Config{
-        Version:         "1.0.0",
-        MinQualityScore: defaultMinQualityScore,
-        UpdateSourceRep: true,
-        QualityConfig: classifier.QualityConfig{
-            WordCountWeight:   defaultQualityWeight,
-            MetadataWeight:    defaultQualityWeight,
-            RichnessWeight:    defaultQualityWeight,
-            ReadabilityWeight: defaultQualityWeight,
-            MinWordCount:      defaultMinWordCount,
-            OptimalWordCount:  defaultOptimalWordCount800,
-        },
-        SourceReputationConfig: classifier.SourceReputationConfig{
-            DefaultScore:               defaultReputationScore70,
-            UpdateOnEachClassification: true,
-            SpamThreshold:              defaultSpamThreshold,
-            MinArticlesForTrust:        minArticlesForTrust,
-            ReputationDecayRate:        defaultReputationDecayRate95,
-        },
-        CrimeClassifier:         createCrimeClassifier(cfg, log),
-        MiningClassifier:        createMiningClassifier(cfg, log),
-        CoforgeClassifier:       createCoforgeClassifier(cfg, log),
-        EntertainmentClassifier: createEntertainmentClassifier(cfg, log),
-        AnishinaabeClassifier:   createAnishinaabeClassifier(cfg, log),
-        RoutingTable:            cfg.Classification.Routing,
-    }
-}
-```
-
-**Step 4: Add the four new classifier constructor functions**
-
-After the existing `createCrimeClassifier` function, add:
-
-```go
-func createMiningClassifier(cfg *config.Config, log infralogger.Logger) *classifier.MiningClassifier {
-    if !cfg.Classification.Mining.Enabled {
-        return nil
-    }
-    var mlClient classifier.MLClassifier
-    if cfg.Classification.Mining.MLServiceURL != "" {
-        mlClient = miningmlclient.NewClient(cfg.Classification.Mining.MLServiceURL)
-    }
-    log.Info("Mining classifier enabled for processor",
-        infralogger.String("ml_service_url", cfg.Classification.Mining.MLServiceURL))
-    return classifier.NewMiningClassifier(mlClient, log, true)
-}
-
-func createCoforgeClassifier(cfg *config.Config, log infralogger.Logger) *classifier.CoforgeClassifier {
-    if !cfg.Classification.Coforge.Enabled {
-        return nil
-    }
-    var mlClient classifier.MLClassifier
-    if cfg.Classification.Coforge.MLServiceURL != "" {
-        mlClient = coforgemlclient.NewClient(cfg.Classification.Coforge.MLServiceURL)
-    }
-    log.Info("Coforge classifier enabled for processor",
-        infralogger.String("ml_service_url", cfg.Classification.Coforge.MLServiceURL))
-    return classifier.NewCoforgeClassifier(mlClient, log, true)
-}
-
-func createEntertainmentClassifier(cfg *config.Config, log infralogger.Logger) *classifier.EntertainmentClassifier {
-    if !cfg.Classification.Entertainment.Enabled {
-        return nil
-    }
-    var mlClient classifier.MLClassifier
-    if cfg.Classification.Entertainment.MLServiceURL != "" {
-        mlClient = entertainmentmlclient.NewClient(cfg.Classification.Entertainment.MLServiceURL)
-    }
-    log.Info("Entertainment classifier enabled for processor",
-        infralogger.String("ml_service_url", cfg.Classification.Entertainment.MLServiceURL))
-    return classifier.NewEntertainmentClassifier(mlClient, log, true)
-}
-
-func createAnishinaabeClassifier(cfg *config.Config, log infralogger.Logger) *classifier.AnishinaabeClassifier {
-    if !cfg.Classification.Anishinaabe.Enabled {
-        return nil
-    }
-    var mlClient classifier.MLClassifier
-    if cfg.Classification.Anishinaabe.MLServiceURL != "" {
-        mlClient = anishinaabemlclient.NewClient(cfg.Classification.Anishinaabe.MLServiceURL)
-    }
-    log.Info("Anishinaabe classifier enabled for processor",
-        infralogger.String("ml_service_url", cfg.Classification.Anishinaabe.MLServiceURL))
-    return classifier.NewAnishinaabeClassifier(mlClient, log, true)
-}
-```
-
-**Step 5: Verify that `classifier.MLClassifier` is the correct interface for the mining/coforge/entertainment/anishinaabe clients**
-
-Check `classifier/internal/classifier/mining.go` to see what interface `NewMiningClassifier` expects as its first parameter. If it's a different interface type (e.g., `*miningmlclient.Client` not `classifier.MLClassifier`), adjust the `var mlClient` type accordingly. The pattern matches `createCrimeClassifier` exactly, so it should be identical.
-
-**Step 6: Run lint and tests**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task lint:classifier && task test:classifier
-```
-
-Expected: all pass.
-
-**Step 7: Commit**
-
-```bash
-git add classifier/cmd/processor/processor.go
-git commit -m "fix(classifier): wire mining/coforge/entertainment/anishinaabe in processor createClassifierConfig"
-```
-
----
-
-## Task 10: Add startup-time routing validation warning in `NewClassifier` (nice-to-have)
-
-**Files:**
-- Modify: `classifier/internal/classifier/classifier.go:52-78`
-
-**Background:** If the routing table references `"mining"` but `MiningClassifier` is nil (disabled), there's no warning at startup — the miss only appears silently at classification time. A startup warn tells operators immediately that their config is inconsistent.
-
-**Step 1: Add sidecar nil-check after building routingTable in `NewClassifier`**
-
-After the `routingTable` is built and the `Classifier` struct is returned, add a validation pass. However, since the `Classifier` struct isn't yet assigned when we're inside `NewClassifier`, we need to check `config` directly:
-
-```go
-func NewClassifier(
-    logger infralogger.Logger,
-    rules []domain.ClassificationRule,
-    sourceRepDB SourceReputationDB,
-    config Config,
-) *Classifier {
-    routingTable := make(map[string][]string)
-    for k, v := range config.RoutingTable {
-        routingTable[k] = append([]string(nil), v...)
-    }
-    // Warn if routing table references a disabled (nil) sidecar classifier.
-    sidecarEnabled := map[string]bool{
-        "crime":         config.CrimeClassifier != nil,
-        "mining":        config.MiningClassifier != nil,
-        "coforge":       config.CoforgeClassifier != nil,
-        "entertainment": config.EntertainmentClassifier != nil,
-        "anishinaabe":   config.AnishinaabeClassifier != nil,
-        "location":      true, // always constructed below
-    }
-    for routeKey, names := range routingTable {
-        for _, name := range names {
-            if enabled, known := sidecarEnabled[name]; known && !enabled {
-                logger.Warn("Routing table references disabled sidecar classifier",
-                    infralogger.String("routing_key", routeKey),
-                    infralogger.String("sidecar_name", name),
-                )
-            }
-        }
-    }
-    return &Classifier{
-        // ... existing fields ...
-    }
-}
-```
-
-**Step 2: Run tests and lint**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier && task lint:classifier
-```
-
-Expected: all pass.
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/classifier/classifier.go
-git commit -m "feat(classifier): warn at startup when routing table references disabled sidecar"
-```
-
----
-
-## Task 11: Warn when classifier is enabled with empty ML URL (nice-to-have)
-
-**Files:**
-- Modify: `classifier/internal/bootstrap/classifier.go:199-215`
-
-**Background:** `createOptionalClassifier` logs `"Crime classifier enabled"` at Info even when `mlURL=""`, meaning the ML component is absent and the sidecar will run rules-only. Operators can't distinguish fully-operational from rules-only mode from logs.
-
-**Step 1: Change the log from unconditional Info to conditional Warn**
-
-In `createOptionalClassifier` (lines 210-213):
-
-```go
-// Before:
-logger.Info(label+" enabled", infralogger.String("ml_service_url", mlURL))
-return newClassifier(client, logger, true)
-
-// After:
-if mlURL == "" {
-    logger.Warn(label+" enabled but ML service URL is empty; running in rules-only mode",
-        infralogger.String("ml_service_url", ""),
-    )
-} else {
-    logger.Info(label+" enabled", infralogger.String("ml_service_url", mlURL))
-}
-return newClassifier(client, logger, true)
-```
-
-**Step 2: Run tests and lint**
-
-```bash
-cd /home/fsd42/dev/north-cloud && task test:classifier && task lint:classifier
-```
-
-Expected: all pass.
-
-**Step 3: Commit**
-
-```bash
-git add classifier/internal/bootstrap/classifier.go
-git commit -m "feat(classifier): warn when classifier is enabled with empty ML URL (rules-only mode)"
-```
-
----
-
-## Final Verification
-
-After all tasks are committed:
-
-```bash
-cd /home/fsd42/dev/north-cloud && task lint:classifier && task test:classifier
-```
-
-Expected: all tests pass, zero lint violations.
-
-Push and update the PR:
-
-```bash
-git push -u origin claude/classifier-declarative-routing
-```
+Expected: all green.


### PR DESCRIPTION
## Summary
Refactors the classifier so optional ML sidecar routing is **declarative and config-driven** instead of hardcoded.

## Changes
- **Config**: `classification.sidecar_registry` (name → enabled, ml_service_url) and `classification.routing` (route key → list of sidecar names) in `config.yml`. Both optional; defaults preserve current behavior.
- **ResolveSidecars(contentType, subtype)**: Lookup order: article → try `article:<subtype>` then `article`; otherwise `content_type`. Logs clearly when no routing key exists.
- **classifyOptionalForPublishable**: Now only calls `ResolveSidecars` and `runOptionalClassifiers(ctx, raw, contentType, sidecars)`; no more hardcoded event/blotter/report branches.
- **runOptionalClassifiers**: Takes `sidecars []string`, runs only those (when classifier instance is non-nil). Per-sidecar logic moved into `run*Optional` helpers (funlen).
- **Bootstrap & processor**: Pass `cfg.Classification.Routing` as `RoutingTable` into classifier config.
- **Tests**: `TestResolveSidecars` and `TestResolveSidecars_MissingKey_ReturnsNilAndLogs`.

## Behaviour
- Public API unchanged (`Classify`, `BuildClassifiedContent`, `ClassificationResult` shape).
- Same effective behaviour for article / article:event / article:blotter / article:report when using default routing.
- Adding new content types or sidecar mappings is config-only (no classifier code changes).

Made with [Cursor](https://cursor.com)