### PR TITLE
fix(grafana): aggregate Loki queries across log streams

### DIFF
--- a/infrastructure/grafana/provisioning/dashboards/north-cloud-pipeline-ops.json
+++ b/infrastructure/grafana/provisioning/dashboards/north-cloud-pipeline-ops.json
@@ -46,7 +46,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "max_over_time({service=\"publisher\"} |= \"Discovered classified content indexes\" | json count=\"count\" | unwrap count [$__range])",
+          "expr": "max(max_over_time({service=\"publisher\"} |= \"Discovered classified content indexes\" | json count=\"count\" | unwrap count [$__range]))",
           "queryType": "instant"
         }
       ],
@@ -90,7 +90,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "count_over_time({service=\"classifier\"} |= \"Classification complete\" [$__range])",
+          "expr": "sum(count_over_time({service=\"classifier\"} |= \"Classification complete\" [$__range]))",
           "queryType": "instant"
         }
       ],
@@ -134,7 +134,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "count_over_time({service=\"publisher\"} |= \"Batch complete\" [$__range])",
+          "expr": "sum(count_over_time({service=\"publisher\"} |= \"Batch complete\" [$__range]))",
           "queryType": "instant"
         }
       ],
@@ -178,7 +178,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "count_over_time({service=\"publisher\"} |= \"Published article to channel\" [$__range])",
+          "expr": "sum(count_over_time({service=\"publisher\"} |= \"Published article to channel\" [$__range]))",
           "queryType": "instant"
         }
       ],
@@ -729,7 +729,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "avg_over_time({service=\"classifier\"} |= \"Batch processing complete\" | json items_per_second=\"items_per_second\" | unwrap items_per_second [$__interval])",
+          "expr": "avg(avg_over_time({service=\"classifier\"} |= \"Batch processing complete\" | json items_per_second=\"items_per_second\" | unwrap items_per_second [$__interval]))",
           "legendFormat": "items/sec"
         }
       ],


### PR DESCRIPTION
## Summary
- Stat panels (Articles Classified, Batches Published, Articles Published, Sources Discovered, Classifier Throughput) showed incorrect values when containers restarted
- Root cause: Loki creates separate log streams per container instance. `count_over_time` returns per-stream values, and the stat panel's `lastNotNull` reducer picks an arbitrary stream instead of summing all streams
- Fix: wrap `count_over_time` with `sum()` and `max_over_time` with `max()` to aggregate across all log streams
- Also wraps `avg_over_time` with `avg()` for the Classifier Throughput Rate panel

## Test plan
- [x] Verified the 30m vs 5m discrepancy is caused by container restart creating multiple Loki streams
- [ ] After deploy, verify the pipeline dashboard shows consistent values across all time ranges
- [ ] Verify stat panels still render correctly (no NaN or missing data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)