### PR TITLE
feat(ai-observer): harden provider, scheduler, and index mapping

### DIFF
--- a/ai-observer/internal/bootstrap/app.go
+++ b/ai-observer/internal/bootstrap/app.go
@@ -52,6 +52,11 @@ func Start() error {
 	}
 	log.Info("Elasticsearch connected", logger.String("url", cfg.ES.URL))
 
+	if err = insights.EnsureMapping(ctx, esClient); err != nil {
+		return fmt.Errorf("ai_insights mapping: %w", err)
+	}
+	log.Info("ai_insights index mapping ready")
+
 	p := anthprovider.New(cfg.Anthropic.APIKey, cfg.Anthropic.DefaultModel)
 	writer := insights.NewWriter(esClient, cfg.Service.Version)
 	cats := buildCategories(cfg, esClient)

--- a/ai-observer/internal/category/classifier/analyzer.go
+++ b/ai-observer/internal/category/classifier/analyzer.go
@@ -15,6 +15,22 @@ const (
 Your job is to identify label drift, borderline clusters, and domains that consistently produce low-confidence classifications.
 Respond ONLY with valid JSON matching the schema provided. Be concise and actionable.`
 
+	// insightJSONSchema is the JSON schema for the LLM response array.
+	// Passed via GenerateRequest.JSONSchema so the provider can enforce it in the system prompt.
+	insightJSONSchema = `{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["severity", "summary", "details", "suggested_actions"],
+    "properties": {
+      "severity":          { "type": "string", "enum": ["low", "medium", "high"] },
+      "summary":           { "type": "string" },
+      "details":           { "type": "object" },
+      "suggested_actions": { "type": "array", "items": { "type": "string" } }
+    }
+  }
+}`
+
 	maxResponseTokens = 1000
 	// maxStatPairs is the max domain+label pairs to include in the LLM prompt.
 	maxStatPairs = 30
@@ -44,6 +60,7 @@ func analyze(ctx context.Context, events []category.Event, p provider.LLMProvide
 		SystemPrompt: systemPrompt,
 		UserPrompt:   userPrompt,
 		MaxTokens:    maxResponseTokens,
+		JSONSchema:   insightJSONSchema,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("generate: %w", err)

--- a/ai-observer/internal/insights/mapping.go
+++ b/ai-observer/internal/insights/mapping.go
@@ -1,0 +1,56 @@
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	es "github.com/elastic/go-elasticsearch/v8"
+)
+
+// insightMapping is the explicit ES mapping for the ai_insights index.
+// keyword fields enable aggregation/sorting without needing .keyword sub-fields.
+var insightMapping = map[string]any{
+	"mappings": map[string]any{
+		"properties": map[string]any{
+			"id":                map[string]any{"type": "keyword"},
+			"created_at":        map[string]any{"type": "date"},
+			"category":          map[string]any{"type": "keyword"},
+			"severity":          map[string]any{"type": "keyword"},
+			"summary":           map[string]any{"type": "text"},
+			"details":           map[string]any{"type": "object", "dynamic": true},
+			"suggested_actions": map[string]any{"type": "text"},
+			"observer_version":  map[string]any{"type": "keyword"},
+			"model":             map[string]any{"type": "keyword"},
+			"tokens_used":       map[string]any{"type": "integer"},
+		},
+	},
+}
+
+// EnsureMapping creates the ai_insights index with an explicit mapping if it does not
+// already exist. Calling this repeatedly is safe — a 400 resource_already_exists_exception
+// is treated as success.
+func EnsureMapping(ctx context.Context, esClient *es.Client) error {
+	mappingBytes, err := json.Marshal(insightMapping)
+	if err != nil {
+		return fmt.Errorf("marshal mapping: %w", err)
+	}
+
+	res, err := esClient.Indices.Create(
+		insightsIndex,
+		esClient.Indices.Create.WithContext(ctx),
+		esClient.Indices.Create.WithBody(bytes.NewReader(mappingBytes)),
+	)
+	if err != nil {
+		return fmt.Errorf("create index: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.IsError() && !strings.Contains(res.String(), "resource_already_exists_exception") {
+		return fmt.Errorf("create index error: %s", res.String())
+	}
+
+	return nil
+}

--- a/ai-observer/internal/provider/anthropic/client.go
+++ b/ai-observer/internal/provider/anthropic/client.go
@@ -3,15 +3,28 @@ package anthropic
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"strings"
+	"time"
 
 	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/provider"
 )
 
-const providerName = "anthropic"
+const (
+	providerName = "anthropic"
+	// maxRetries is the number of attempts for rate-limited requests.
+	maxRetries = 3
+	// retryBaseDelay is the initial backoff delay before jitter.
+	retryBaseDelay = 250 * time.Millisecond
+	// rateLimitStatus is the HTTP status code for rate limiting.
+	rateLimitStatus = 429
+	// retryJitterDivisor controls max jitter as a fraction of base delay (base/2 = up to 50%).
+	retryJitterDivisor = 2
+)
 
 // Client wraps the Anthropic SDK client and implements provider.LLMProvider.
 type Client struct {
@@ -33,24 +46,59 @@ func (c *Client) Name() string {
 }
 
 // Generate sends a prompt to the Anthropic Messages API and returns the response.
+// Retries up to maxRetries times on 429 rate-limit responses with exponential backoff and jitter.
 func (c *Client) Generate(ctx context.Context, req provider.GenerateRequest) (provider.GenerateResponse, error) {
 	params := buildParams(c.model, req)
 
-	msg, err := c.inner.Messages.New(ctx, params)
-	if err != nil {
-		return provider.GenerateResponse{}, fmt.Errorf("anthropic generate: %w", err)
+	var lastErr error
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			delay := retryDelay(attempt)
+			select {
+			case <-ctx.Done():
+				return provider.GenerateResponse{}, fmt.Errorf("context cancelled during retry: %w", ctx.Err())
+			case <-time.After(delay):
+			}
+		}
+
+		msg, err := c.inner.Messages.New(ctx, params)
+		if err == nil {
+			return provider.GenerateResponse{
+				Content:      extractText(msg.Content),
+				InputTokens:  int(msg.Usage.InputTokens),
+				OutputTokens: int(msg.Usage.OutputTokens),
+			}, nil
+		}
+
+		if !isRateLimit(err) {
+			return provider.GenerateResponse{}, fmt.Errorf("anthropic generate: %w", err)
+		}
+		lastErr = err
 	}
 
-	text := extractText(msg.Content)
+	return provider.GenerateResponse{}, fmt.Errorf("anthropic generate: rate limited after %d attempts: %w", maxRetries, lastErr)
+}
 
-	return provider.GenerateResponse{
-		Content:      text,
-		InputTokens:  int(msg.Usage.InputTokens),
-		OutputTokens: int(msg.Usage.OutputTokens),
-	}, nil
+// retryDelay returns the backoff duration for the given attempt (1-indexed).
+// Delay doubles each attempt: 250ms, 500ms, 1s — plus up to 50% random jitter.
+func retryDelay(attempt int) time.Duration {
+	base := retryBaseDelay * (1 << attempt)
+	jitter := time.Duration(rand.Int64N(int64(base / retryJitterDivisor)))
+	return base + jitter
+}
+
+// isRateLimit reports whether err is an Anthropic 429 rate-limit error.
+func isRateLimit(err error) bool {
+	var apiErr *anthropicsdk.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == rateLimitStatus
+	}
+	return false
 }
 
 // buildParams constructs MessageNewParams from a GenerateRequest.
+// If JSONSchema is set, it is appended to the system prompt so the model
+// knows the exact output structure required.
 func buildParams(model anthropicsdk.Model, req provider.GenerateRequest) anthropicsdk.MessageNewParams {
 	params := anthropicsdk.MessageNewParams{
 		Model:     model,
@@ -62,13 +110,26 @@ func buildParams(model anthropicsdk.Model, req provider.GenerateRequest) anthrop
 		},
 	}
 
-	if req.SystemPrompt != "" {
+	systemText := buildSystemPrompt(req.SystemPrompt, req.JSONSchema)
+	if systemText != "" {
 		params.System = []anthropicsdk.TextBlockParam{
-			{Text: req.SystemPrompt},
+			{Text: systemText},
 		}
 	}
 
 	return params
+}
+
+// buildSystemPrompt assembles the final system prompt, appending the JSON schema
+// constraint when provided.
+func buildSystemPrompt(base, jsonSchema string) string {
+	if jsonSchema == "" {
+		return base
+	}
+	if base == "" {
+		return "Output must conform to the following JSON schema:\n" + jsonSchema
+	}
+	return base + "\n\nOutput must conform to the following JSON schema:\n" + jsonSchema
 }
 
 // extractText returns the concatenated text from all text content blocks.

--- a/ai-observer/internal/scheduler/scheduler.go
+++ b/ai-observer/internal/scheduler/scheduler.go
@@ -191,7 +191,10 @@ func (s *Scheduler) runCategory(ctx context.Context, cat category.Category, budg
 
 	estimatedTokens := len(events) * tokensPerEvent
 	if !budget.Deduct(estimatedTokens) {
-		s.logInfo("budget exhausted, skipping category", logger.String("category", cat.Name()))
+		s.logInfo("budget_exceeded",
+			logger.String("category", cat.Name()),
+			logger.Int("estimated_tokens", estimatedTokens),
+		)
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary

Four reliability patches for the AI Observer service, following on from #145:

- **429 retry with backoff**: Anthropic client retries up to 3× on rate-limit responses with exponential backoff (250ms → 500ms → 1s) + 50% jitter. Context cancellation respected between attempts.
- **`budget_exceeded` structured log**: Replaces unstructured string with a keyed log event (`budget_exceeded`) carrying `category` and `estimated_tokens` fields — filterable in Grafana.
- **`ai_insights` ES index mapping**: `EnsureMapping()` creates the index with explicit types on startup (`severity`/`category` as `keyword`, `created_at` as `date`, `tokens_used` as `integer`). Idempotent — `resource_already_exists_exception` is success.
- **JSONSchema enforcement**: Classifier analyzer passes `insightJSONSchema` in `GenerateRequest.JSONSchema`; Anthropic client appends it to the system prompt. Gives the model an explicit structural constraint, reducing parse failures.

## What's not in this PR (correctly deferred)

- Sidecar analyzer — blocked on Redis Streams operational events from classifier/pipeline
- Ingestion analyzer — blocked on Loki HTTP client in `infrastructure/`

## Test plan

- [ ] `cd ai-observer && GOWORK=off go test ./...` — all pass
- [ ] `cd ai-observer && GOWORK=off golangci-lint run --config ../.golangci.yml ./...` — 0 issues
- [ ] `AI_OBSERVER_ENABLED=true AI_OBSERVER_DRY_RUN=true ANTHROPIC_API_KEY=dummy GOWORK=off go run .` — starts, logs mapping ready, scheduler starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)