### PR TITLE
docs(governance): add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug in a NorthCloud service
+labels: bug
+---
+
+## Service
+
+Which service is affected? (e.g., crawler, classifier, publisher)
+
+## Description
+
+What happened?
+
+## Expected Behavior
+
+What should have happened?
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- Branch/commit:
+- Docker or local:
+- Relevant logs:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement
+labels: enhancement
+---
+
+## Service
+
+Which service(s) will this affect?
+
+## Description
+
+What do you want to build?
+
+## Motivation
+
+Why is this needed? What problem does it solve?
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Design Doc
+
+Link to design document in `docs/plans/` if available:

--- a/.github/ISSUE_TEMPLATE/spec-update.md
+++ b/.github/ISSUE_TEMPLATE/spec-update.md
@@ -1,0 +1,17 @@
+---
+name: Spec Update
+about: Report or fix spec drift between documentation and code
+labels: spec-drift
+---
+
+## Spec File
+
+Which spec has drifted? (e.g., `docs/specs/content-routing.md`)
+
+## What Changed in Code
+
+Describe what the code does now that the spec doesn't reflect:
+
+## Proposed Spec Fix
+
+Describe what the spec should say:


### PR DESCRIPTION
## Summary
- Add bug report template (.github/ISSUE_TEMPLATE/bug.md)
- Add feature request template (.github/ISSUE_TEMPLATE/feature.md)
- Add spec update template (.github/ISSUE_TEMPLATE/spec-update.md)
- Migrate issues #158 and #160 to M3: Observability Hardening milestone

Closes #166

## Test plan
- [ ] Issue templates appear when creating new issues on GitHub
- [ ] Issues #158 and #160 are in M3 milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)