### PR TITLE
docs(specs): audit and fix spec drift across all services

### DIFF
--- a/docs/specs/ai-observer.md
+++ b/docs/specs/ai-observer.md
@@ -1,0 +1,95 @@
+# AI Observer Spec
+
+> Last verified: 2026-03-08
+
+## Overview
+
+Advisory-only service that periodically samples content from Elasticsearch, sends it to an LLM (Anthropic Claude) for analysis, and writes insights to a dedicated `ai_insights` ES index. Never modifies ingestion pipeline indices. Disabled by default.
+
+---
+
+## File Map
+
+```
+ai-observer/
+  main.go                          # Calls bootstrap.Start()
+  Dockerfile                       # Multi-stage alpine, uid 1000
+  internal/
+    bootstrap/                     # Config -> logger -> ES -> provider -> categories -> scheduler
+    provider/                      # LLMProvider interface + Anthropic implementation
+    category/                      # Category interface, Event, Insight types
+      classifier/                  # Classifier drift category (ES sampling + LLM analysis)
+    insights/                      # ai_insights ES index writer + mapping
+    scheduler/                     # Ticker loop + cost-ceiling token budget
+```
+
+---
+
+## API Reference
+
+No HTTP API. The service runs as a background scheduler that writes to Elasticsearch.
+
+### Grafana Dashboard
+
+Available at `/d/north-cloud-ai-insights`:
+- Overview stats (total insights, severity counts, token usage, error count)
+- Trends (insights over time by severity, token usage over time)
+- Severity/category/model breakdowns
+- Service logs (Loki) and recent insights table (ES)
+
+Datasource: `ai-insights` (uid: `ai-insights`) pointing to `ai_insights` index with `created_at` time field.
+
+---
+
+## Data Model
+
+### ai_insights ES index
+
+| Field | ES Type | Description |
+|-------|---------|-------------|
+| `category` | keyword | Category of insight (e.g., `classifier_drift`) |
+| `severity` | keyword | `info`, `warning`, `critical` |
+| `title` | text | Human-readable insight title |
+| `description` | text | Detailed insight description |
+| `details` | flattened | LLM-generated structured details (inconsistent types, stored as strings) |
+| `source_name` | keyword | Source name being analyzed |
+| `model` | keyword | LLM model used |
+| `tokens_used` | integer | Tokens consumed for this insight |
+| `created_at` | date | When the insight was generated |
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AI_OBSERVER_ENABLED` | `false` | Enable the service |
+| `AI_OBSERVER_DRY_RUN` | `false` | Log intent without LLM calls |
+| `AI_OBSERVER_INTERVAL_SECONDS` | `1800` | Polling interval (30 min) |
+| `AI_OBSERVER_MAX_TOKENS_PER_INTERVAL` | `25000` | Token budget ceiling per interval |
+| `AI_OBSERVER_CATEGORY_CLASSIFIER_ENABLED` | `true` | Enable classifier drift category |
+| `ANTHROPIC_API_KEY` | — | Required when enabled |
+| `ES_URL` | `http://localhost:9200` | Elasticsearch URL |
+
+---
+
+## Known Constraints
+
+- **Disabled by default**: `AI_OBSERVER_ENABLED=false` means zero production impact until explicitly enabled.
+- **Advisory only**: never writes to ingestion pipeline indices (`*_raw_content`, `*_classified_content`).
+- **Dry-run mode**: `AI_OBSERVER_DRY_RUN=true` short-circuits before any LLM call.
+- **Token budget is pre-estimated**: `len(events) * 50`, not reconciled against actual API spend.
+- **Per-category timeout**: 5 minutes to prevent goroutine stalls.
+- **ES mapping changes require manual index deletion**: `EnsureMapping` only creates the index if it doesn't exist. After changing the mapping, manually delete the index and restart.
+- **`details` field uses flattened ES type**: avoids dynamic type conflicts from inconsistent LLM output.
+- **`ANTHROPIC_API_KEY` only required when enabled**: service exits cleanly when disabled without API key.
+
+### Rollout Phases
+
+| Phase | Action |
+|-------|--------|
+| 0 (current) | Merged with `AI_OBSERVER_ENABLED=false` |
+| 1 | Enable with `DRY_RUN=true` (logs prompts + projected cost) |
+| 2 | Live calls in dev, review first insights manually |
+| 3 | Production with classifier category only |
+| 4 | Add sidecar/ingestion categories (requires upstream event emission) |

--- a/docs/specs/auth.md
+++ b/docs/specs/auth.md
@@ -1,0 +1,85 @@
+# Auth Service Spec
+
+> Last verified: 2026-03-08
+
+## Overview
+
+Single-user authentication service. Validates credentials against one username/password pair (from environment variables) and issues HS256-signed JWT tokens. No user database.
+
+---
+
+## File Map
+
+```
+auth/
+  main.go                          # Entry point: profiling → config → logger → server
+  config.yml                       # Default configuration
+  internal/
+    api/
+      server.go                    # Gin server builder, route registration
+      auth_handler.go              # Login handler: credential validation, JWT response
+    auth/
+      jwt.go                       # JWTManager: GenerateToken, ValidateToken
+    config/
+      config.go                    # Config struct, setDefaults, Validate, GetJWTConfig
+```
+
+---
+
+## API Reference
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/health` | None | Returns 200 OK |
+| POST | `/api/v1/auth/login` | None | Validate credentials, return JWT |
+
+**Login request**:
+```json
+{"username": "admin", "password": "secret"}
+```
+
+**Login response (200)**:
+```json
+{"token": "eyJhbGciOiJIUzI1NiIs..."}
+```
+
+**Error responses**: `400` (bad/missing fields), `401` (wrong credentials), `500` (token generation failure).
+
+---
+
+## Data Model
+
+**JWT Claims** (HS256):
+- `sub`: always `"dashboard"`
+- `iat`: issued-at Unix timestamp
+- `nbf`: not-before (same as `iat`)
+- `exp`: issued-at + expiration duration (default 24h)
+
+No database. No refresh tokens.
+
+---
+
+## Configuration
+
+| Variable | yaml key | Default | Required | Description |
+|----------|----------|---------|----------|-------------|
+| `AUTH_USERNAME` | `auth.username` | `admin` | Yes | Login username |
+| `AUTH_PASSWORD` | `auth.password` | `admin` | Yes | Login password |
+| `AUTH_JWT_SECRET` | `auth.jwt_secret` | `change-me-in-production` | Yes (prod) | HS256 signing secret |
+| `AUTH_PORT` | `service.port` | `8040` | No | HTTP listen port |
+| `APP_DEBUG` | `service.debug` | `false` | No | Debug mode (relaxes JWT secret validation) |
+| `LOG_LEVEL` | `logging.level` | `info` | No | Log level |
+| `LOG_FORMAT` | `logging.format` | `json` | No | Log format |
+
+`jwt_expiration` is only configurable via `config.yml` (Go duration string, e.g., `"24h"`).
+
+---
+
+## Known Constraints
+
+- **Single user only**: one username/password pair from env vars. No user management API.
+- **JWT secret must match across all services**: every service using `infraJWT.Middleware` reads `AUTH_JWT_SECRET`. Mismatch causes 401 on all requests.
+- **No refresh tokens**: clients re-authenticate on expiry (default 24h).
+- **Default secret rejected in production**: if `APP_DEBUG=false` and `AUTH_JWT_SECRET` is empty or `"change-me-in-production"`, the service exits at startup.
+- **Health endpoint always public**: `/health` bypasses JWT validation.
+- **Bootstrap pattern**: simple (helper functions in `main.go`, no `internal/bootstrap/` package).

--- a/docs/specs/classification.md
+++ b/docs/specs/classification.md
@@ -1,5 +1,7 @@
 # Classification Specification
 
+> Last verified: 2026-03-08
+
 Covers the classifier service, hybrid rule+ML classification pipeline, ML sidecar integration, and content enrichment.
 
 ## File Map

--- a/docs/specs/click-tracker.md
+++ b/docs/specs/click-tracker.md
@@ -1,0 +1,114 @@
+# Click Tracker Spec
+
+> Last verified: 2026-03-08
+
+## Overview
+
+Click event tracking service. Receives HMAC-signed redirect URLs from the search service, verifies signatures, buffers click events in-memory, and batch-flushes to PostgreSQL. Bots are detected and excluded. Privacy by design: destination URLs and user agents are stored as hashes.
+
+---
+
+## File Map
+
+```
+click-tracker/
+  main.go                          # Config -> logger -> DB -> server
+  cmd/migrate/main.go              # Database migration runner
+  migrations/
+    001_create_click_events.*      # Partitioned click_events table
+  internal/
+    api/
+      server.go                    # Gin server via infragin builder
+      routes.go                    # Route wiring (BotFilter + RateLimiter)
+    config/config.go               # Config struct, defaults, env binding
+    domain/click_event.go          # ClickEvent value type
+    handler/
+      click.go                     # HandleClick: parse -> verify -> expiry -> buffer
+      health.go                    # /health endpoint
+    middleware/
+      botfilter.go                 # UA-based bot detection (24 patterns)
+      ratelimit.go                 # In-memory per-IP sliding window rate limiter
+    storage/postgres.go            # Buffer (channel) + Store (batch INSERT)
+```
+
+---
+
+## API Reference
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/click` | None | Verify signature, buffer event, 302 redirect |
+| GET | `/health` | None | Liveness check |
+| GET | `/health/memory` | None | Memory usage stats |
+
+### /click query parameters
+
+`q` (query ID), `r` (result ID), `p` (position), `pg` (page), `t` (Unix timestamp), `u` (destination URL, URL-encoded), `sig` (HMAC signature, 12 hex chars).
+
+### Error responses
+
+| Status | Cause |
+|--------|-------|
+| 400 | Missing or unparseable required parameters |
+| 403 | Invalid HMAC signature |
+| 410 | URL older than `max_timestamp_age` (default 24h) |
+| 429 | Per-IP rate limit exceeded |
+
+---
+
+## Data Model
+
+### click_events table (partitioned by `RANGE (clicked_at)`)
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `query_id` | text | Search query identifier |
+| `result_id` | text | Clicked result identifier |
+| `position` | int | Result position on page |
+| `page` | int | Search result page number |
+| `destination_hash` | text | SHA-256 of destination URL (privacy) |
+| `user_agent_hash` | text | First 12 hex chars of SHA-256 of UA |
+| `ip_hash` | text | Hashed client IP |
+| `clicked_at` | timestamp | Event timestamp |
+
+### Privacy design
+
+- Raw destination URL never stored (only SHA-256 hash)
+- User-Agent stored as truncated hash
+- Bot clicks are never enqueued
+
+### Buffering
+
+- In-memory channel (default capacity 1,000)
+- Non-blocking send: full buffer drops event (redirect still completes)
+- Batch flush: 500 events or 1 second, whichever comes first
+- Chunks of 50 rows per INSERT statement
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLICK_TRACKER_PORT` | `8093` | HTTP listen port |
+| `CLICK_TRACKER_SECRET` | — | HMAC signing secret (required, must match search service) |
+| `APP_DEBUG` | `false` | Gin debug mode |
+| `POSTGRES_CLICK_TRACKER_HOST` | `localhost` | PostgreSQL host |
+| `POSTGRES_CLICK_TRACKER_PORT` | `5432` | PostgreSQL port |
+| `POSTGRES_CLICK_TRACKER_USER` | `postgres` | PostgreSQL user |
+| `POSTGRES_CLICK_TRACKER_PASSWORD` | — | PostgreSQL password |
+| `POSTGRES_CLICK_TRACKER_DB` | `click_tracker` | PostgreSQL database |
+| `LOG_LEVEL` | `info` | Log level |
+| `LOG_FORMAT` | `json` | Log format |
+
+---
+
+## Known Constraints
+
+- **Secret mismatch causes all clicks to return 403**: `CLICK_TRACKER_SECRET` must match the search service.
+- **Buffer drops are silent to users**: when full, events are dropped but redirects succeed. Monitor `buffer full` log entries.
+- **`CLICK_TRACKER_ENABLED` lives in the search service, not here**: this service always processes requests. The flag controls URL rewriting in search.
+- **Migrations must run before service start**: no auto-migration.
+- **Partitions must be created manually**: `click_events_default` catches all rows until named range partitions are added.
+- **Bot filter is UA-based**: 24 crawler patterns checked case-insensitively. Empty UA treated as bot.
+- **Rate limiter is in-memory and per-process**: no cross-instance coordination.

--- a/docs/specs/content-acquisition.md
+++ b/docs/specs/content-acquisition.md
@@ -1,5 +1,7 @@
 # Content Acquisition Specification
 
+> Last verified: 2026-03-08
+
 Covers the crawler subsystem: web content fetching, job scheduling, frontier URL management, and raw content indexing.
 
 ## File Map

--- a/docs/specs/content-routing.md
+++ b/docs/specs/content-routing.md
@@ -1,6 +1,8 @@
 # Content Routing Specification
 
-Covers the publisher service: 10-layer routing pipeline, channel management, Redis publishing, and deduplication.
+> Last verified: 2026-03-08
+
+Covers the publisher service: 11-layer routing pipeline, channel management, Redis publishing, and deduplication.
 
 ## File Map
 
@@ -19,6 +21,7 @@ Covers the publisher service: 10-layer routing pipeline, channel management, Red
 | `publisher/internal/router/domain_coforge.go` | Layer 8: Coforge routing |
 | `publisher/internal/router/domain_recipe.go` | Layer 9: Recipe routing |
 | `publisher/internal/router/domain_job.go` | Layer 10: Job routing |
+| `publisher/internal/router/domain_rfp.go` | Layer 11: RFP routing |
 | `publisher/internal/router/content_item.go` | ContentItem struct (all classification fields) |
 | `publisher/internal/models/channel.go` | Channel, ChannelCreateRequest |
 | `publisher/internal/models/rules.go` | Rules struct + Matches() |
@@ -71,12 +74,12 @@ func (s *Service) Start(ctx context.Context) error  // Main loop
 ```
 ES *_classified_content → Router (30s poll, batch=100, search_after cursor)
 
-For each ContentItem, evaluate 10 layers sequentially:
+For each ContentItem, evaluate 11 layers sequentially:
 
 Layer 1 (TopicDomain):
   For each topic NOT in layer1SkipTopics:
     → publish to content:{topic}
-  Skip topics: mining, indigenous, coforge, recipe, jobs
+  Skip topics: mining, indigenous, coforge, recipe, jobs, rfp
 
 Layer 2 (DBChannelDomain):
   For each enabled channel in database:
@@ -130,6 +133,14 @@ Layer 9 (RecipeDomain):
 Layer 10 (JobDomain):
   If content_type == "job" and job result present:
     → content:jobs
+
+Layer 11 (RFPDomain):
+  If content_type == "rfp" or rfp result present:
+    → content:rfps
+    Per country → rfp:country:{code}
+    Per province → rfp:province:{code}
+    Per category → rfp:sector:{slug}
+    Per procurement type → rfp:type:{slug}
 ```
 
 ### Publishing Flow
@@ -150,6 +161,7 @@ var layer1SkipTopics = map[string]bool{
     "coforge":    true,  // Layer 8 ML filter
     "recipe":     true,
     "jobs":       true,
+    "rfp":        true,  // Layer 11 RFP filter
 }
 ```
 Topics in this map MUST be skipped to prevent bypassing ML classification filters.

--- a/docs/specs/dashboard.md
+++ b/docs/specs/dashboard.md
@@ -1,0 +1,82 @@
+# Dashboard Spec
+
+> Last verified: 2026-03-08
+
+## Overview
+
+Vue 3 SPA that provides the operator UI for managing sources, crawl jobs, channels, classification rules, and monitoring pipeline health. Communicates with backend services via a Vite dev proxy (dev) or nginx reverse proxy (prod).
+
+---
+
+## File Map
+
+```
+dashboard/src/
+  App.vue                  # Root component
+  main.ts                  # Entry point
+  style.css                # Global styles (Tailwind 4 @import syntax)
+  router/index.ts          # Vue Router config, auth guard, route definitions
+  stores/                  # Pinia state stores
+  api/
+    client.ts              # Shared Axios instance with auth interceptor
+    auth.ts                # Auth API calls
+  components/              # Reusable UI components (ui/, layout/, domain/, crawler/, etc.)
+  views/                   # Page components (distribution/, feeds/, intake/, intelligence/, etc.)
+  composables/             # Vue composables (useAuth, usePolling, useRealtime, etc.)
+  types/                   # TypeScript interfaces
+  config/                  # App-level configuration constants
+```
+
+---
+
+## API Proxy Targets
+
+The dashboard does not call backend services directly. In development, Vite proxies requests:
+
+| Frontend prefix | Service | Default target |
+|-----------------|---------|----------------|
+| `/api/crawler` | Crawler | `http://localhost:8060` |
+| `/api/sources`, `/api/cities` | Source Manager | `http://localhost:8050` |
+| `/api/publisher` | Publisher | `http://localhost:8070` |
+| `/api/classifier` | Classifier | `http://localhost:8071` |
+| `/api/v1/auth`, `/api/auth` | Auth | `http://localhost:8040` |
+| `/api/index-manager` | Index Manager | `http://localhost:8090` |
+
+---
+
+## Data Model
+
+Core TypeScript interfaces defined in `src/types/`:
+
+- **Source**: id, name, url, selectors, enabled
+- **Channel**: id, name, description, enabled
+- **Route**: id, source_id, channel_id, min_quality_score, topics, enabled
+
+---
+
+## Configuration
+
+Backend targets are Vite server-side proxy targets (not `VITE_` runtime vars):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CRAWLER_API_URL` | `http://localhost:8060` | Crawler API |
+| `SOURCES_API_URL` | `http://localhost:8050` | Source Manager API |
+| `PUBLISHER_API_URL` | `http://localhost:8070` | Publisher API |
+| `CLASSIFIER_API_URL` | `http://localhost:8071` | Classifier API |
+| `AUTH_API_URL` | `http://localhost:8040` | Auth service |
+| `INDEX_MANAGER_API_URL` | `http://localhost:8090` | Index Manager API |
+
+Port: 3002 (dev server).
+
+---
+
+## Known Constraints
+
+- **No `any` types**: ESLint enforces strict TypeScript. Use `unknown` and type guards.
+- **Tailwind CSS v4**: uses `@import "tailwindcss"` syntax (not v3 `@tailwind` directives).
+- **Auth token key**: `localStorage` key is `dashboard_token` (not `auth_token`).
+- **No VITE_ runtime env vars for backend URLs**: all routing goes through Vite proxy config.
+- **Vue Router base path**: `createWebHistory('/dashboard/')`. Production serves under `/dashboard/`.
+- **SSE proxy timeout**: `/api/crawler` proxy has a 1-hour timeout for SSE log streaming.
+- **Framework**: Vue 3 Composition API + TypeScript + Vite + TanStack Vue Query.

--- a/docs/specs/discovery-querying.md
+++ b/docs/specs/discovery-querying.md
@@ -1,5 +1,7 @@
 # Discovery & Querying Specification
 
+> Last verified: 2026-03-08
+
 Covers the search service (full-text queries) and index-manager (ES lifecycle, mappings, aggregations).
 
 ## File Map

--- a/docs/specs/mcp-server.md
+++ b/docs/specs/mcp-server.md
@@ -1,5 +1,7 @@
 # MCP Server Spec
 
+> Last verified: 2026-03-08
+
 Covers `mcp-north-cloud/`: the Claude Code / Cursor MCP server that exposes north-cloud pipeline operations as tools.
 
 ## File Map
@@ -10,8 +12,9 @@ Covers `mcp-north-cloud/`: the Claude Code / Cursor MCP server that exposes nort
 | `mcp-north-cloud/run-mcp.sh` | Wrapper: loads .env, ensures clean stdout |
 | `mcp-north-cloud/test-tools.sh` | Smoke test: verifies tool count by env |
 | `mcp-north-cloud/internal/mcp/server.go` | Request routing, toolHandlers map, prompts/resources dispatch |
-| `mcp-north-cloud/internal/mcp/tools.go` | 26 tool definitions scoped by MCP_ENV |
-| `mcp-north-cloud/internal/mcp/handlers.go` | Tool implementations (one func per tool) |
+| `mcp-north-cloud/internal/mcp/tools.go` | 28 tool definitions scoped by MCP_ENV |
+| `mcp-north-cloud/internal/mcp/handlers.go` | Tool implementations (one func per tool, except fetch_url) |
+| `mcp-north-cloud/internal/mcp/fetch_url.go` | fetch_url tool handler |
 | `mcp-north-cloud/internal/mcp/types.go` | JSON-RPC types, Scope constants |
 | `mcp-north-cloud/internal/mcp/prompts.go` | 4 prompt templates |
 | `mcp-north-cloud/internal/mcp/resources.go` | Static doc resources |
@@ -30,7 +33,7 @@ Covers `mcp-north-cloud/`: the Claude Code / Cursor MCP server that exposes nort
 | Method | Description |
 |--------|-------------|
 | `initialize` | Returns protocol version `2024-11-05` + capabilities |
-| `tools/list` | Returns tools for current `MCP_ENV` (18 local / 23 prod) |
+| `tools/list` | Returns tools for current `MCP_ENV` (19 local / 25 prod) |
 | `tools/call` | Routes `params.name` to registered handler |
 | `prompts/list` | Returns 4 prompt templates |
 | `prompts/get` | Returns messages for a named prompt |
@@ -42,23 +45,25 @@ Covers `mcp-north-cloud/`: the Claude Code / Cursor MCP server that exposes nort
 
 | Environment | Count | Scope |
 |-------------|-------|-------|
-| `local` (default) | 18 | shared (15) + local-only (3) |
-| `prod` | 23 | shared (15) + prod-only (8) |
-| Total definitions | 26 | 15 shared + 3 local + 8 prod |
+| `local` (default) | 19 | shared (16) + local-only (3) |
+| `prod` | 25 | shared (16) + prod-only (9) |
+| Total definitions | 28 | 16 shared + 3 local + 9 prod |
 
 ### Tools by Category
 
 | Category | Tools |
 |----------|-------|
-| Workflow | onboard_source |
+| System (1) | health_check |
+| Workflow (1) | onboard_source |
 | Crawler (5) | start_crawl, schedule_crawl, list_crawl_jobs, control_crawl_job, get_crawl_stats |
 | Source Manager (5) | add_source, list_sources, update_source, delete_source, test_source |
 | Publisher (6) | create_channel, list_channels, delete_channel, preview_channel, get_publish_history, get_publisher_stats |
-| Search | search_content |
-| Classifier | classify_content |
+| Search (1) | search_content |
+| Classifier (1) | classify_content |
 | Index Manager (2) | list_indexes, delete_index |
-| Auth | get_auth_token |
-| Observability | get_grafana_alerts |
+| Auth (1) | get_auth_token |
+| Observability (1) | get_grafana_alerts |
+| Fetch (1) | fetch_url |
 | Development (3) | lint_file, build_service, test_service |
 
 ## Data Flow
@@ -82,17 +87,22 @@ Security hardening layer:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MCP_ENV` | `local` | Tool scope: `local` (18) or `prod` (23) |
-| `CRAWLER_URL` | `http://localhost:8080` | Crawler service |
+| `MCP_ENV` | `local` | Tool scope: `local` (19) or `prod` (25) |
+| `CRAWLER_URL` | `http://localhost:8060` | Crawler service |
 | `SOURCE_MANAGER_URL` | `http://localhost:8050` | Source manager |
 | `PUBLISHER_URL` | `http://localhost:8070` | Publisher |
-| `CLASSIFIER_URL` | `http://localhost:8071` | Classifier |
-| `SEARCH_URL` | `http://localhost:8092` | Search service |
+| `CLASSIFIER_URL` | `http://localhost:8070` | Classifier (shares publisher default) |
+| `SEARCH_URL` | `http://localhost:8090` | Search service |
 | `INDEX_MANAGER_URL` | `http://localhost:8090` | Index manager |
 | `GRAFANA_URL` | `http://localhost:3000` | Grafana |
+| `GRAFANA_USERNAME` | — | Grafana admin username (for alerts) |
+| `GRAFANA_PASSWORD` | — | Grafana admin password (for alerts) |
 | `AUTH_JWT_SECRET` | — | Required for protected tools |
 | `MCP_HTTP_TIMEOUT_SECONDS` | `30` | HTTP client timeout |
 | `NORTH_CLOUD_ROOT` | cwd | Repo root for lint_file/build_service |
+| `OLLAMA_URL` | — | Ollama API URL (for fetch_url extract_schema) |
+| `OLLAMA_MODEL` | `qwen3:4b` | Ollama model for schema-guided extraction |
+| `RENDERER_URL` | — | Playwright renderer sidecar (for JS-heavy pages) |
 
 ## Known Constraints
 
@@ -101,4 +111,4 @@ Security hardening layer:
 - **EOF = graceful shutdown**: When stdin closes the server exits cleanly. Not an error.
 - **No authentication at MCP layer**: Callers are not authenticated by the server itself. Protected tools use `AUTH_JWT_SECRET` for service-to-service JWT tokens.
 - **Scope counts are test fixtures**: `scope_test.go` and `test-tools.sh` hardcode expected tool counts. Update both whenever tools are added or removed.
-- **Adding a tool (4-step workflow)**: (1) define in `tools.go`, (2) register handler in `server.go`, (3) implement in `handlers.go`, (4) update counts in `scope_test.go` + `test-tools.sh`.
+- **Adding a tool (4-step workflow)**: (1) define in `tools.go`, (2) register handler in `server.go`, (3) implement in `handlers.go` (or a dedicated file for complex tools), (4) update counts in `scope_test.go` + `test-tools.sh`.

--- a/docs/specs/pipeline.md
+++ b/docs/specs/pipeline.md
@@ -1,0 +1,85 @@
+# Pipeline Service Spec
+
+> Last verified: 2026-03-08
+
+## Overview
+
+Pipeline event tracking service. Records content lifecycle events (crawled, indexed, classified, routed, published) with idempotent writes. Provides a funnel query for observability. No external service dependencies beyond PostgreSQL.
+
+---
+
+## File Map
+
+```
+pipeline/
+  main.go                            # Calls bootstrap.Start()
+  migrations/
+    001_create_pipeline_events.up.sql # Partitioned events table + content_items + stage_ordering
+  internal/
+    bootstrap/                       # Config -> logger -> database -> HTTP server
+    config/                          # Config struct, YAML + env loading, validation
+    database/                        # PostgreSQL repository (idempotent inserts)
+    domain/                          # Stage, ContentItem, PipelineEvent, IngestRequest, FunnelResponse
+    service/                         # PipelineService: validation, idempotency, write + read
+    api/                             # HTTP handlers + route registration
+```
+
+---
+
+## API Reference
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/api/v1/events` | None | Ingest one event |
+| `POST` | `/api/v1/events/batch` | None | Ingest multiple events |
+| `GET` | `/api/v1/funnel` | JWT | Pipeline funnel (period: `today`, `24h`, `7d`, `30d`) |
+| `GET` | `/health` | None | Liveness + database ping |
+
+Write endpoints are intentionally unauthenticated (internal Docker network only).
+
+---
+
+## Data Model
+
+### Five Pipeline Stages
+
+```
+crawled -> indexed -> classified -> routed -> published
+```
+
+### Tables
+
+- **content_items**: `url` (PK), `url_hash` (SHA-256), `domain`, `source_name`, `created_at`
+- **pipeline_events**: partitioned by `occurred_at` (monthly ranges). Fields: `id`, `idempotency_key`, `content_url`, `source_name`, `stage`, `service_name`, `occurred_at`, `metadata` (JSONB)
+- **stage_ordering**: maps stages to sort order for funnel queries
+
+### Idempotency
+
+Each event has an `idempotency_key`. Auto-generated format: `{serviceName}:{stage}:{urlHash8}:{occurredAt}`. Database enforces uniqueness on `(idempotency_key, occurred_at)`.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PIPELINE_PORT` | `8075` | HTTP listen port |
+| `APP_DEBUG` | `false` | Gin debug mode |
+| `POSTGRES_PIPELINE_HOST` | `localhost` | DB host |
+| `POSTGRES_PIPELINE_PORT` | `5432` | DB port |
+| `POSTGRES_PIPELINE_USER` | `postgres` | DB user |
+| `POSTGRES_PIPELINE_PASSWORD` | _(empty)_ | DB password |
+| `POSTGRES_PIPELINE_DB` | `pipeline` | DB name |
+| `AUTH_JWT_SECRET` | _(empty)_ | Shared JWT secret (for funnel endpoint) |
+| `LOG_LEVEL` | `info` | Log level |
+| `LOG_FORMAT` | `json` | Log format |
+
+---
+
+## Known Constraints
+
+- **Partition maintenance required**: initial migration ships partitions for 2026 Q1-Q2. Add partitions before each quarter ends, or inserts fail.
+- **Non-UTC timestamps rejected**: `occurred_at` must be `time.UTC` location (pointer comparison).
+- **24-hour event age limit**: events older than 24h rejected with validation error.
+- **Batch stops on first error**: `IngestBatch` processes sequentially, returns on first failure.
+- **Write endpoints are unauthenticated**: rely on Docker network isolation. Do not expose port 8075 publicly.

--- a/docs/specs/rfp-ingestor.md
+++ b/docs/specs/rfp-ingestor.md
@@ -1,5 +1,7 @@
 # RFP Ingestor Spec
 
+> Last verified: 2026-03-08
+
 ## Overview
 
 Stand-alone feed ingestor that polls CanadaBuys CSV feeds and bulk-indexes documents to Elasticsearch. **Bypasses the classifier** — has no connection to the classifier or publisher pipeline. Documents become discoverable via the search service through the `*_classified_content` ES index wildcard.

--- a/docs/specs/shared-infrastructure.md
+++ b/docs/specs/shared-infrastructure.md
@@ -1,5 +1,7 @@
 # Shared Infrastructure Specification
 
+> Last verified: 2026-03-08
+
 Covers the `infrastructure/` module: config loading, logging, database clients, middleware, events, and utilities used by all services.
 
 ## File Map

--- a/docs/specs/social-publisher.md
+++ b/docs/specs/social-publisher.md
@@ -1,5 +1,7 @@
 # Social Publisher Spec
 
+> Last verified: 2026-03-08
+
 ## Overview
 
 Social media delivery service. Subscribes to Redis pub/sub for inbound publish requests, delivers content to platform adapters (currently X/Twitter), tracks delivery lifecycle in Postgres, and retries failures with exponential backoff.


### PR DESCRIPTION
## Summary
- Audited 8 existing specs against current code, fixed all drift (code wins over docs)
- Added `Last verified: 2026-03-08` to all 13 specs
- Created stub specs for 5 undocumented services: auth, pipeline, dashboard, click-tracker, ai-observer

### Drift fixes
- **content-routing.md**: Fixed "10-layer" to "11-layer" (RFP is Layer 11), added `rfp` to `layer1SkipTopics` (code has 6 entries, spec had 5), added `domain_rfp.go` to file map
- **mcp-server.md**: Fixed tool counts from 26 to 28 (16 shared + 3 local + 9 prod), fixed `CRAWLER_URL` default from `8080` to `8060`, `CLASSIFIER_URL` from `8071` to `8070`, `SEARCH_URL` from `8092` to `8090`, added `fetch_url` and `health_check` tools to category table, added missing config vars (`GRAFANA_USERNAME`, `GRAFANA_PASSWORD`, `OLLAMA_URL`, `OLLAMA_MODEL`, `RENDERER_URL`), added `fetch_url.go` to file map

### No drift found in
- content-acquisition.md, classification.md, discovery-querying.md, shared-infrastructure.md, social-publisher.md, rfp-ingestor.md

Closes #165

## Test plan
- [x] All 13 spec files exist in `docs/specs/`
- [x] Each spec has `Last verified: 2026-03-08` line
- [x] Drift fixes verified against actual source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)