### PR TITLE
refactor(governance): standardize Go module paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ ML sidecars (crime-ml, mining-ml, coforge-ml, entertainment-ml, indigenous-ml) l
 - **Standards**: `gofmt`, `goimports`, standard Go formatting
 - **Error Handling**: Always wrap errors: `fmt.Errorf("context: %w", err)`
 - **Logging**: All services use `infrastructure/logger` package directly
-  - Import: `infralogger "github.com/north-cloud/infrastructure/logger"`
+  - Import: `infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"`
   - Always JSON format, structured fields with snake_case
   - Example: `log.Info("Service started", infralogger.String("service", "crawler"))`
 - **Database**: Always use context-aware methods (`PingContext()`, `QueryContext()`, etc.)

--- a/ai-observer/go.mod
+++ b/ai-observer/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/anthropics/anthropic-sdk-go v1.26.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.3
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -26,4 +26,4 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/ai-observer/internal/bootstrap/app.go
+++ b/ai-observer/internal/bootstrap/app.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/insights"
 	anthprovider "github.com/jonesrussell/north-cloud/ai-observer/internal/provider/anthropic"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/scheduler"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Start initializes and runs the ai-observer service.

--- a/ai-observer/internal/bootstrap/elasticsearch.go
+++ b/ai-observer/internal/bootstrap/elasticsearch.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	es "github.com/elastic/go-elasticsearch/v8"
-	infraes "github.com/north-cloud/infrastructure/elasticsearch"
-	"github.com/north-cloud/infrastructure/logger"
+	infraes "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SetupElasticsearch creates and verifies the ES client using infrastructure package.

--- a/ai-observer/internal/bootstrap/logger.go
+++ b/ai-observer/internal/bootstrap/logger.go
@@ -1,7 +1,7 @@
 package bootstrap
 
 import (
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // CreateLogger initializes the structured logger.

--- a/ai-observer/internal/scheduler/scheduler.go
+++ b/ai-observer/internal/scheduler/scheduler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/category"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/insights"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/provider"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/auth/CLAUDE.md
+++ b/auth/CLAUDE.md
@@ -63,7 +63,7 @@ auth/
 
 **Debug mode**: When `APP_DEBUG=true` (or `service.debug: true` in config), the JWT secret validation is relaxed, allowing the default placeholder secret. Never use debug mode in production.
 
-**Infrastructure Gin server**: Auth uses `infragin.NewServerBuilder` from `github.com/north-cloud/infrastructure/gin`. This provides consistent server configuration (timeouts, health endpoint, graceful shutdown) across all services. Auth does NOT apply the JWT middleware to its own routes — it is the issuer.
+**Infrastructure Gin server**: Auth uses `infragin.NewServerBuilder` from `github.com/jonesrussell/north-cloud/infrastructure/gin`. This provides consistent server configuration (timeouts, health endpoint, graceful shutdown) across all services. Auth does NOT apply the JWT middleware to its own routes — it is the issuer.
 
 ## API Reference
 
@@ -156,7 +156,7 @@ All test helper functions call `t.Helper()` at the top as required by the linter
 Other services validate tokens using the shared middleware from `infrastructure/jwt`:
 
 ```go
-import infraJWT "github.com/north-cloud/infrastructure/jwt"
+import infraJWT "github.com/jonesrussell/north-cloud/infrastructure/jwt"
 
 // Register middleware on protected route group
 v1 := router.Group("/api/v1")

--- a/auth/README.md
+++ b/auth/README.md
@@ -182,7 +182,7 @@ The `AUTH_JWT_SECRET` value must be identical across all services. A mismatch ca
 Example middleware wiring in another service:
 
 ```go
-import infraJWT "github.com/north-cloud/infrastructure/jwt"
+import infraJWT "github.com/jonesrussell/north-cloud/infrastructure/jwt"
 
 // Apply to all /api/v1/* routes
 v1 := router.Group("/api/v1")

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -46,4 +46,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/auth/internal/api/auth_handler.go
+++ b/auth/internal/api/auth_handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/auth/internal/auth"
 	"github.com/jonesrussell/north-cloud/auth/internal/config"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // AuthHandler handles authentication requests.

--- a/auth/internal/api/auth_handler_test.go
+++ b/auth/internal/api/auth_handler_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jonesrussell/north-cloud/auth/internal/api"
 	"github.com/jonesrussell/north-cloud/auth/internal/auth"
 	"github.com/jonesrussell/north-cloud/auth/internal/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 type mockLogger struct{}

--- a/auth/internal/api/server.go
+++ b/auth/internal/api/server.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/auth/internal/auth"
 	"github.com/jonesrussell/north-cloud/auth/internal/config"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/auth/internal/config/config.go
+++ b/auth/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default configuration values.

--- a/auth/main.go
+++ b/auth/main.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/jonesrussell/north-cloud/auth/internal/api"
 	"github.com/jonesrussell/north-cloud/auth/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	"github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 func main() {

--- a/classifier/cmd/processor/processor.go
+++ b/classifier/cmd/processor/processor.go
@@ -21,10 +21,10 @@ import (
 	"github.com/jonesrussell/north-cloud/classifier/internal/mlclient"
 	"github.com/jonesrussell/north-cloud/classifier/internal/processor"
 	"github.com/jonesrussell/north-cloud/classifier/internal/storage"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 )
 
 const (

--- a/classifier/go.mod
+++ b/classifier/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.2
 	github.com/mattn/go-sqlite3 v1.14.32
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.40.0
@@ -71,4 +71,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/classifier/internal/api/handlers.go
+++ b/classifier/internal/api/handlers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jonesrussell/north-cloud/classifier/internal/mlhealth"
 	"github.com/jonesrussell/north-cloud/classifier/internal/processor"
 	"github.com/jonesrussell/north-cloud/classifier/internal/storage"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/api/handlers_test.go
+++ b/classifier/internal/api/handlers_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/processor"
 	"github.com/jonesrussell/north-cloud/classifier/internal/testhelpers"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	_ "github.com/mattn/go-sqlite3"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // mockLogger implements Logger for testing

--- a/classifier/internal/api/internal_handler.go
+++ b/classifier/internal/api/internal_handler.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // InternalExtractRequest represents a request to the internal extract endpoint.

--- a/classifier/internal/api/internal_handler_test.go
+++ b/classifier/internal/api/internal_handler_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/classifier/internal/config"
-	infragin "github.com/north-cloud/infrastructure/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
 )
 
 const testInternalSecret = "test-secret-123"

--- a/classifier/internal/api/routes.go
+++ b/classifier/internal/api/routes.go
@@ -4,9 +4,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/classifier/internal/config"
 	"github.com/jonesrussell/north-cloud/classifier/internal/telemetry"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infrajwt "github.com/north-cloud/infrastructure/jwt"
-	"github.com/north-cloud/infrastructure/monitoring"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infrajwt "github.com/jonesrussell/north-cloud/infrastructure/jwt"
+	"github.com/jonesrussell/north-cloud/infrastructure/monitoring"
 )
 
 // SetupRoutes configures all API routes

--- a/classifier/internal/api/server.go
+++ b/classifier/internal/api/server.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/classifier/internal/config"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // setupInternalRoutes configures internal service-to-service endpoints.

--- a/classifier/internal/bootstrap/classifier.go
+++ b/classifier/internal/bootstrap/classifier.go
@@ -16,8 +16,8 @@ import (
 	"github.com/jonesrussell/north-cloud/classifier/internal/miningmlclient"
 	"github.com/jonesrussell/north-cloud/classifier/internal/mlclient"
 	"github.com/jonesrussell/north-cloud/classifier/internal/processor"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/bootstrap/config.go
+++ b/classifier/internal/bootstrap/config.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // LoadConfig loads configuration. Uses defaults if file doesn't exist.

--- a/classifier/internal/bootstrap/database.go
+++ b/classifier/internal/bootstrap/database.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/jonesrussell/north-cloud/classifier/internal/config"
 	"github.com/jonesrussell/north-cloud/classifier/internal/database"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // DatabaseComponents holds database connection and repositories.

--- a/classifier/internal/bootstrap/storage.go
+++ b/classifier/internal/bootstrap/storage.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/config"
 	"github.com/jonesrussell/north-cloud/classifier/internal/storage"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/retry"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/retry"
 )
 
 // SetupElasticsearch creates optional Elasticsearch storage for re-classification.

--- a/classifier/internal/classifier/classifier.go
+++ b/classifier/internal/classifier/classifier.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/classifier/classifier_routing_test.go
+++ b/classifier/internal/classifier/classifier_routing_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/testhelpers"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // recordingLogger wraps mockLogger and records all Warn calls for assertion.

--- a/classifier/internal/classifier/coforge.go
+++ b/classifier/internal/classifier/coforge.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/coforgemlclient"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const coforgeMaxBodyChars = 500

--- a/classifier/internal/classifier/content_type.go
+++ b/classifier/internal/classifier/content_type.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier/jsonld"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/classifier/content_type_event_heuristic.go
+++ b/classifier/internal/classifier/content_type_event_heuristic.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Event keyword heuristic constants.

--- a/classifier/internal/classifier/content_type_job_heuristic.go
+++ b/classifier/internal/classifier/content_type_job_heuristic.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // jobKeywords are phrases whose presence (case-insensitive) strongly

--- a/classifier/internal/classifier/content_type_obituary_heuristic.go
+++ b/classifier/internal/classifier/content_type_obituary_heuristic.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // obituaryKeywords are phrases whose presence (case-insensitive) strongly

--- a/classifier/internal/classifier/content_type_recipe_heuristic.go
+++ b/classifier/internal/classifier/content_type_recipe_heuristic.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // recipeKeywords are phrases whose presence (case-insensitive) strongly

--- a/classifier/internal/classifier/content_type_rfp_heuristic.go
+++ b/classifier/internal/classifier/content_type_rfp_heuristic.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // rfpKeywords are phrases whose presence (case-insensitive) strongly

--- a/classifier/internal/classifier/content_type_test.go
+++ b/classifier/internal/classifier/content_type_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/classifier/internal/classifier/crime.go
+++ b/classifier/internal/classifier/crime.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/mlclient"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Crime classification thresholds.

--- a/classifier/internal/classifier/entertainment.go
+++ b/classifier/internal/classifier/entertainment.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/entertainmentmlclient"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const entertainmentMaxBodyChars = 500

--- a/classifier/internal/classifier/indigenous.go
+++ b/classifier/internal/classifier/indigenous.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/indigenousmlclient"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const indigenousMaxBodyChars = 500

--- a/classifier/internal/classifier/job_extractor.go
+++ b/classifier/internal/classifier/job_extractor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier/jsonld"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Job extractor constants.

--- a/classifier/internal/classifier/location.go
+++ b/classifier/internal/classifier/location.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/data"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Zone weights for location scoring.

--- a/classifier/internal/classifier/location_test.go
+++ b/classifier/internal/classifier/location_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // mockLogger implements the Logger interface for testing.

--- a/classifier/internal/classifier/mining.go
+++ b/classifier/internal/classifier/mining.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/miningmlclient"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const miningMaxBodyChars = 500

--- a/classifier/internal/classifier/observability.go
+++ b/classifier/internal/classifier/observability.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const titleExcerptWordLimit = 10

--- a/classifier/internal/classifier/quality.go
+++ b/classifier/internal/classifier/quality.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/classifier/recipe_extractor.go
+++ b/classifier/internal/classifier/recipe_extractor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier/jsonld"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Extraction method constants.

--- a/classifier/internal/classifier/rfp_extractor.go
+++ b/classifier/internal/classifier/rfp_extractor.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // RFP extractor constants.

--- a/classifier/internal/classifier/rule_engine.go
+++ b/classifier/internal/classifier/rule_engine.go
@@ -14,7 +14,7 @@ import (
 	ahocorasick "github.com/cloudflare/ahocorasick"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/telemetry"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // RuleMatch represents a matched rule with scoring details

--- a/classifier/internal/classifier/source_reputation.go
+++ b/classifier/internal/classifier/source_reputation.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/classifier/topic.go
+++ b/classifier/internal/classifier/topic.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/config/config.go
+++ b/classifier/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default configuration values.

--- a/classifier/internal/database/postgres.go
+++ b/classifier/internal/database/postgres.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	infracontext "github.com/jonesrussell/north-cloud/infrastructure/context"
 	_ "github.com/lib/pq" // PostgreSQL driver
-	infracontext "github.com/north-cloud/infrastructure/context"
 )
 
 const (

--- a/classifier/internal/processor/batch.go
+++ b/classifier/internal/processor/batch.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // BatchProcessor processes multiple content items in parallel using a worker pool

--- a/classifier/internal/processor/batch_v2.go
+++ b/classifier/internal/processor/batch_v2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/telemetry"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/processor/integration_test.go
+++ b/classifier/internal/processor/integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jonesrussell/north-cloud/classifier/internal/classifier"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/storage"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // mockLogger implements the Logger interface for testing

--- a/classifier/internal/processor/poller.go
+++ b/classifier/internal/processor/poller.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 )
 
 const (

--- a/classifier/internal/processor/poller_test.go
+++ b/classifier/internal/processor/poller_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // mockLoggerWithCalls tracks log calls for testing

--- a/classifier/internal/processor/ratelimiter.go
+++ b/classifier/internal/processor/ratelimiter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"golang.org/x/time/rate"
 )
 

--- a/classifier/internal/server/httpd.go
+++ b/classifier/internal/server/httpd.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/bootstrap"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 // StartHTTPServer starts the HTTP server for the classifier service (blocking).

--- a/classifier/internal/storage/database_adapter.go
+++ b/classifier/internal/storage/database_adapter.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/database"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/classifier/internal/storage/database_adapter_test.go
+++ b/classifier/internal/storage/database_adapter_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // mockLoggerWithCalls tracks log calls for testing

--- a/classifier/internal/storage/elasticsearch.go
+++ b/classifier/internal/storage/elasticsearch.go
@@ -10,7 +10,7 @@ import (
 
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	"github.com/north-cloud/infrastructure/naming"
+	"github.com/jonesrussell/north-cloud/infrastructure/naming"
 )
 
 // ElasticsearchStorage implements storage operations for the classifier

--- a/classifier/internal/storage/index_naming.go
+++ b/classifier/internal/storage/index_naming.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/north-cloud/infrastructure/naming"
+	"github.com/jonesrussell/north-cloud/infrastructure/naming"
 )
 
 // ClassifiedIndexForContent determines the classified index name for a content item.

--- a/classifier/internal/storage/logger.go
+++ b/classifier/internal/storage/logger.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // NewComponentLogger creates a logger with a structured "component" field

--- a/classifier/internal/storage/outbox_writer.go
+++ b/classifier/internal/storage/outbox_writer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // OutboxWriter writes classified content to the publisher outbox for guaranteed delivery.

--- a/classifier/main.go
+++ b/classifier/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/cmd/processor"
 	"github.com/jonesrussell/north-cloud/classifier/internal/server"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const version = "1.0.0"

--- a/click-tracker/cmd/migrate/main.go
+++ b/click-tracker/cmd/migrate/main.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Exit codes for the migrate command.

--- a/click-tracker/go.mod
+++ b/click-tracker/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/lib/pq v1.10.9
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -49,4 +49,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/click-tracker/internal/api/server.go
+++ b/click-tracker/internal/api/server.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/config"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/click-tracker/internal/config/config.go
+++ b/click-tracker/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default configuration values.

--- a/click-tracker/internal/handler/click.go
+++ b/click-tracker/internal/handler/click.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/domain"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/storage"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // errMissingParams is returned when required query parameters are absent or unparseable.

--- a/click-tracker/internal/handler/click_test.go
+++ b/click-tracker/internal/handler/click_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/middleware"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/storage"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/click-tracker/internal/storage/postgres.go
+++ b/click-tracker/internal/storage/postgres.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Named constants to avoid magic numbers.

--- a/click-tracker/main.go
+++ b/click-tracker/main.go
@@ -11,10 +11,10 @@ import (
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/config"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/storage"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	"github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 
 	_ "github.com/lib/pq"
 )

--- a/crawler/go.mod
+++ b/crawler/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.98
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mmcdole/gofeed v1.3.0
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/temoto/robotstxt v1.1.2
 	golang.org/x/net v0.51.0
@@ -103,6 +103,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 
 replace github.com/jonesrussell/north-cloud/index-manager => ../index-manager

--- a/crawler/internal/admin/sync_enabled_sources.go
+++ b/crawler/internal/admin/sync_enabled_sources.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/api/api.go
+++ b/crawler/internal/api/api.go
@@ -9,8 +9,8 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/admin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/api/discovered_domains_handler.go
+++ b/crawler/internal/api/discovered_domains_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/api/discovered_domains_handler_test.go
+++ b/crawler/internal/api/discovered_domains_handler_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestIsValidDomainStatus(t *testing.T) {

--- a/crawler/internal/api/discovered_links_handler.go
+++ b/crawler/internal/api/discovered_links_handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/api/frontier_handler.go
+++ b/crawler/internal/api/frontier_handler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/frontier"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/api/internal_handler.go
+++ b/crawler/internal/api/internal_handler.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gin-gonic/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Fetch timeout constraints.

--- a/crawler/internal/api/internal_handler_test.go
+++ b/crawler/internal/api/internal_handler_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const testHTML = `<!DOCTYPE html>

--- a/crawler/internal/api/jobs_handler.go
+++ b/crawler/internal/api/jobs_handler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/api/logs_handler.go
+++ b/crawler/internal/api/logs_handler.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 )
 
 // Constants for log handler operations.

--- a/crawler/internal/api/logs_stream_v2_handler.go
+++ b/crawler/internal/api/logs_stream_v2_handler.go
@@ -11,8 +11,8 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 )
 
 // Constants for v2 stream handler.

--- a/crawler/internal/api/logs_stream_v2_handler_test.go
+++ b/crawler/internal/api/logs_stream_v2_handler_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/api"
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestLogsStreamV2Handler_Stream(t *testing.T) {

--- a/crawler/internal/api/middleware/security.go
+++ b/crawler/internal/api/middleware/security.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/server"
 	"github.com/jonesrussell/north-cloud/crawler/internal/metrics"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SecurityMiddlewareInterface defines the interface for security middleware.

--- a/crawler/internal/api/migration_handler.go
+++ b/crawler/internal/api/migration_handler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Default migration batch size.

--- a/crawler/internal/api/sse_handler.go
+++ b/crawler/internal/api/sse_handler.go
@@ -3,8 +3,8 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 )
 
 // SSEHandler handles Server-Sent Events endpoints.

--- a/crawler/internal/archive/archiver.go
+++ b/crawler/internal/archive/archiver.go
@@ -16,9 +16,9 @@ import (
 	"unicode"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/minio"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	miniogo "github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // Archiver handles HTML archiving to MinIO object storage.

--- a/crawler/internal/archive/worker.go
+++ b/crawler/internal/archive/worker.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // UploadWorker processes upload tasks asynchronously.

--- a/crawler/internal/bootstrap/app.go
+++ b/crawler/internal/bootstrap/app.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/api"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 // StaleURLRecoverer recovers frontier URLs stuck in 'fetching' state.

--- a/crawler/internal/bootstrap/config.go
+++ b/crawler/internal/bootstrap/config.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // === Errors ===

--- a/crawler/internal/bootstrap/events.go
+++ b/crawler/internal/bootstrap/events.go
@@ -8,7 +8,7 @@ import (
 	crawlerintevents "github.com/jonesrussell/north-cloud/crawler/internal/events"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SetupEventConsumer creates and starts the event consumer if Redis events are enabled.

--- a/crawler/internal/bootstrap/export_test.go
+++ b/crawler/internal/bootstrap/export_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // MapExtractedToRawContentForTest exposes mapExtractedToRawContent for testing.

--- a/crawler/internal/bootstrap/fetcher_adapters.go
+++ b/crawler/internal/bootstrap/fetcher_adapters.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/apiclient"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // publishedDateFormats lists time formats to try when parsing published dates from HTML meta tags.

--- a/crawler/internal/bootstrap/fetcher_adapters_test.go
+++ b/crawler/internal/bootstrap/fetcher_adapters_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/bootstrap"
 	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestMapExtractedToRawContent_AllFields(t *testing.T) {

--- a/crawler/internal/bootstrap/frontier_logging.go
+++ b/crawler/internal/bootstrap/frontier_logging.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // loggingFrontierRepo wraps FrontierRepository and logs every Submit for Grafana/Loki.

--- a/crawler/internal/bootstrap/lifecycle.go
+++ b/crawler/internal/bootstrap/lifecycle.go
@@ -10,9 +10,9 @@ import (
 	crawlerintevents "github.com/jonesrussell/north-cloud/crawler/internal/events"
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
 	"github.com/jonesrussell/north-cloud/crawler/internal/scheduler"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/sse"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 )
 
 // === Constants ===

--- a/crawler/internal/bootstrap/redis.go
+++ b/crawler/internal/bootstrap/redis.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
-	infraredis "github.com/north-cloud/infrastructure/redis"
+	infraredis "github.com/jonesrussell/north-cloud/infrastructure/redis"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/crawler/internal/bootstrap/server.go
+++ b/crawler/internal/bootstrap/server.go
@@ -9,8 +9,8 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const syncStaggerMinutes = 5

--- a/crawler/internal/bootstrap/services.go
+++ b/crawler/internal/bootstrap/services.go
@@ -23,9 +23,9 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/apiclient"
 	crawlstorage "github.com/jonesrussell/north-cloud/crawler/internal/storage"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
-	"github.com/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/crawler/internal/bootstrap/storage.go
+++ b/crawler/internal/bootstrap/storage.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // StorageComponents holds both storage interface and index manager.

--- a/crawler/internal/config/config.go
+++ b/crawler/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/minio"
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/server"
 	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Interface defines the interface for configuration management.

--- a/crawler/internal/content/rawcontent/processor.go
+++ b/crawler/internal/content/rawcontent/processor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/jonesrussell/north-cloud/crawler/internal/content"
 	"github.com/jonesrussell/north-cloud/crawler/internal/content/contenttype"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // RawContentProcessor implements the content.Processor interface for raw content extraction.

--- a/crawler/internal/content/rawcontent/service.go
+++ b/crawler/internal/content/rawcontent/service.go
@@ -14,8 +14,8 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
 	storagepkg "github.com/jonesrussell/north-cloud/crawler/internal/storage"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 )
 
 // minPostExtractionWordCount is the minimum word count for extracted content to be indexed.

--- a/crawler/internal/coordination/leader.go
+++ b/crawler/internal/coordination/leader.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/crawler/internal/crawler/constructor.go
+++ b/crawler/internal/crawler/constructor.go
@@ -17,8 +17,8 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/proxypool"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/crawler/internal/crawler/crawler.go
+++ b/crawler/internal/crawler/crawler.go
@@ -19,7 +19,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/metrics"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
 	storagetypes "github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/crawler/internal/crawler/events/default_handler.go
+++ b/crawler/internal/crawler/events/default_handler.go
@@ -3,7 +3,7 @@ package events
 import (
 	"context"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // DefaultHandler provides a basic implementation of EventHandler that logs events.

--- a/crawler/internal/crawler/events/eventbus.go
+++ b/crawler/internal/crawler/events/eventbus.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // EventBus implements the crawler.EventBus interface for managing event distribution.

--- a/crawler/internal/crawler/factory_concurrency_test.go
+++ b/crawler/internal/crawler/factory_concurrency_test.go
@@ -7,7 +7,7 @@ import (
 	crawlerconfig "github.com/jonesrussell/north-cloud/crawler/internal/config/crawler"
 	"github.com/jonesrussell/north-cloud/crawler/internal/crawler"
 	"github.com/jonesrussell/north-cloud/crawler/internal/crawler/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const concurrentJobCount = 10

--- a/crawler/internal/crawler/factory_test.go
+++ b/crawler/internal/crawler/factory_test.go
@@ -7,7 +7,7 @@ import (
 	crawlerconfig "github.com/jonesrussell/north-cloud/crawler/internal/config/crawler"
 	"github.com/jonesrussell/north-cloud/crawler/internal/crawler"
 	"github.com/jonesrussell/north-cloud/crawler/internal/crawler/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func testParams(t *testing.T) crawler.CrawlerParams {

--- a/crawler/internal/crawler/html_processor.go
+++ b/crawler/internal/crawler/html_processor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/content"
 	"github.com/jonesrussell/north-cloud/crawler/internal/content/contenttype"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // defaultProcessorsCapacity is the pre-allocated capacity for processor slice

--- a/crawler/internal/crawler/link_handler.go
+++ b/crawler/internal/crawler/link_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/frontier"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // LinkFrontierSubmitter submits discovered URLs to the frontier queue.

--- a/crawler/internal/crawler/signals.go
+++ b/crawler/internal/crawler/signals.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/crawler"
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SignalCoordinator manages cancellation signals and cleanup operations.

--- a/crawler/internal/crawler/state.go
+++ b/crawler/internal/crawler/state.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // State implements the CrawlerState and CrawlerMetrics interfaces.

--- a/crawler/internal/database/postgres.go
+++ b/crawler/internal/database/postgres.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	infracontext "github.com/jonesrussell/north-cloud/infrastructure/context"
 	_ "github.com/lib/pq" // PostgreSQL driver
-	infracontext "github.com/north-cloud/infrastructure/context"
 )
 
 const (

--- a/crawler/internal/events/consumer.go
+++ b/crawler/internal/events/consumer.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/crawler/internal/events/consumer_test.go
+++ b/crawler/internal/events/consumer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/events"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // MockHandler implements events.EventHandler for testing.

--- a/crawler/internal/events/handler.go
+++ b/crawler/internal/events/handler.go
@@ -4,7 +4,7 @@ package events
 import (
 	"context"
 
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // EventHandler processes source lifecycle events.

--- a/crawler/internal/events/noop_handler.go
+++ b/crawler/internal/events/noop_handler.go
@@ -4,8 +4,8 @@ package events
 import (
 	"context"
 
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // NoOpHandler logs events but takes no action.

--- a/crawler/internal/events/noop_handler_test.go
+++ b/crawler/internal/events/noop_handler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/events"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 func TestNoOpHandler_AllMethods_ReturnNil(t *testing.T) {

--- a/crawler/internal/job/event_service.go
+++ b/crawler/internal/job/event_service.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // ErrJobNotFoundBySourceID is returned when no job exists for a given source ID.

--- a/crawler/internal/job/event_service_test.go
+++ b/crawler/internal/job/event_service_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/events"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // MockJobRepository implements job.Repository for testing.

--- a/crawler/internal/job/migrator.go
+++ b/crawler/internal/job/migrator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // MigrationRepository defines the interface for migration-related job operations.

--- a/crawler/internal/job/service.go
+++ b/crawler/internal/job/service.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/metrics"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // BaseService provides base job service functionality.

--- a/crawler/internal/logs/archiver.go
+++ b/crawler/internal/logs/archiver.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/minio"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	miniogo "github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/logs/publisher.go
+++ b/crawler/internal/logs/publisher.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync/atomic"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 )
 
 // ssePublisher implements Publisher for SSE log streaming.

--- a/crawler/internal/logs/service.go
+++ b/crawler/internal/logs/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // activeWriter tracks an active log writer for a job execution.

--- a/crawler/internal/logs/service_test.go
+++ b/crawler/internal/logs/service_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestNewService_WithRedis(t *testing.T) {

--- a/crawler/internal/scheduler/interval_scheduler.go
+++ b/crawler/internal/scheduler/interval_scheduler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/scheduler/sse_publisher.go
+++ b/crawler/internal/scheduler/sse_publisher.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
 )
 
 // Progress tracking constants.

--- a/crawler/internal/sources/apiclient/client.go
+++ b/crawler/internal/sources/apiclient/client.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	infrahttp "github.com/north-cloud/infrastructure/http"
+	infrahttp "github.com/jonesrussell/north-cloud/infrastructure/http"
 )
 
 const (

--- a/crawler/internal/sources/loader.go
+++ b/crawler/internal/sources/loader.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // NewSources creates a new Sources instance without loading sources immediately.

--- a/crawler/internal/sources/loader/api_loader.go
+++ b/crawler/internal/sources/loader/api_loader.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/apiclient"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // APILoader handles loading source configurations from the source-manager API.

--- a/crawler/internal/sources/sources.go
+++ b/crawler/internal/sources/sources.go
@@ -11,7 +11,7 @@ import (
 	configtypes "github.com/jonesrussell/north-cloud/crawler/internal/config/types"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/loader"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Interface defines the read-only interface for accessing sources.

--- a/crawler/internal/storage/client.go
+++ b/crawler/internal/storage/client.go
@@ -9,8 +9,8 @@ import (
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
 	"github.com/jonesrussell/north-cloud/crawler/internal/config/elasticsearch"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // ClientParams contains dependencies for creating the Elasticsearch client

--- a/crawler/internal/storage/document_ops.go
+++ b/crawler/internal/storage/document_ops.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // IndexDocument indexes a document in Elasticsearch

--- a/crawler/internal/storage/elasticsearch_index_manager.go
+++ b/crawler/internal/storage/elasticsearch_index_manager.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/crawler/internal/storage/helpers.go
+++ b/crawler/internal/storage/helpers.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Helper function to create a context with timeout

--- a/crawler/internal/storage/index_ops.go
+++ b/crawler/internal/storage/index_ops.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // CreateIndex creates a new index with the specified mapping

--- a/crawler/internal/storage/mapping_ops.go
+++ b/crawler/internal/storage/mapping_ops.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // GetMapping retrieves the mapping for an index

--- a/crawler/internal/storage/raw_content_indexer.go
+++ b/crawler/internal/storage/raw_content_indexer.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
 	"github.com/jonesrussell/north-cloud/index-manager/pkg/contracts"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/naming"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/naming"
 )
 
 // RawContent represents minimally-processed content for classification

--- a/crawler/internal/storage/raw_content_indexer_test.go
+++ b/crawler/internal/storage/raw_content_indexer_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // mockIndexManager records the mapping passed to EnsureIndex for assertions.

--- a/crawler/internal/storage/search.go
+++ b/crawler/internal/storage/search.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SearchDocuments performs a search query and decodes the result into the provided value

--- a/crawler/internal/storage/storage.go
+++ b/crawler/internal/storage/storage.go
@@ -6,7 +6,7 @@ import (
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/jonesrussell/north-cloud/crawler/internal/config"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage/types"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Constants for timeout durations

--- a/crawler/internal/worker/health.go
+++ b/crawler/internal/worker/health.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // HealthStatus represents the health status of the pool.

--- a/crawler/internal/worker/pool.go
+++ b/crawler/internal/worker/pool.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/queue"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // PoolState represents the current state of the pool.

--- a/crawler/internal/worker/worker.go
+++ b/crawler/internal/worker/worker.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/queue"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // WorkerState represents the current state of a worker.

--- a/docs/architecture/classifier_publisher_dashboard.md
+++ b/docs/architecture/classifier_publisher_dashboard.md
@@ -734,7 +734,7 @@ import (
 	"github.com/north-cloud/classifier/internal/classifier"
 	"github.com/north-cloud/classifier/internal/domain"
 	"github.com/north-cloud/classifier/internal/telemetry"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (
@@ -1720,7 +1720,7 @@ import (
 	"github.com/north-cloud/publisher/internal/database"
 	"github.com/north-cloud/publisher/internal/domain"
 	"github.com/north-cloud/publisher/internal/telemetry"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/docs/plans/2026-01-28-job-logging-pipeline-implementation.md
+++ b/docs/plans/2026-01-28-job-logging-pipeline-implementation.md
@@ -1438,7 +1438,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Heartbeat interval for long-running jobs.

--- a/docs/plans/2026-01-29-automated-job-lifecycle-design.md
+++ b/docs/plans/2026-01-29-automated-job-lifecycle-design.md
@@ -210,7 +210,7 @@ import (
 
     "github.com/google/uuid"
     "github.com/redis/go-redis/v9"
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 type Publisher struct {
@@ -383,7 +383,7 @@ import (
     "time"
 
     "github.com/redis/go-redis/v9"
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (
@@ -616,7 +616,7 @@ import (
 
     "github.com/google/uuid"
     "github.com/north-cloud/crawler/internal/events"
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 type Service struct {

--- a/docs/plans/2026-01-29-automated-job-lifecycle-phase1.md
+++ b/docs/plans/2026-01-29-automated-job-lifecycle-phase1.md
@@ -381,7 +381,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // MockRedisClient implements a minimal mock for testing
@@ -441,8 +441,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Publisher publishes source events to Redis Streams.
@@ -536,7 +536,7 @@ func (p *Publisher) PublishAsync(event infraevents.SourceEvent) {
 ### Step 4: Add dependency and run test
 
 ```bash
-cd source-manager && go get github.com/north-cloud/infrastructure/events
+cd source-manager && go get github.com/jonesrussell/north-cloud/infrastructure/events
 cd source-manager && go test ./internal/events/... -v
 ```
 
@@ -583,7 +583,7 @@ Edit `source-manager/internal/handlers/source.go`:
 import (
 	// ... existing imports ...
 	"github.com/jonesrussell/north-cloud/source-manager/internal/events"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // Modify struct
@@ -828,7 +828,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // MockHandler implements EventHandler for testing
@@ -905,7 +905,7 @@ package events
 import (
 	"context"
 
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // EventHandler processes source lifecycle events.
@@ -933,8 +933,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (
@@ -1210,7 +1210,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 func TestNoOpHandler_HandleSourceCreated_LogsAndReturnsNil(t *testing.T) {
@@ -1255,8 +1255,8 @@ package events
 import (
 	"context"
 
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // NoOpHandler logs events but takes no action.

--- a/docs/plans/2026-01-30-automated-job-lifecycle-phase2.md
+++ b/docs/plans/2026-01-30-automated-job-lifecycle-phase2.md
@@ -965,7 +965,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/events"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 // MockJobRepository implements job.Repository for testing.
@@ -1257,8 +1257,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Repository defines the interface for job persistence.

--- a/docs/plans/2026-01-30-automated-job-lifecycle-phase3.md
+++ b/docs/plans/2026-01-30-automated-job-lifecycle-phase3.md
@@ -490,7 +490,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // MigrationRepository defines the interface for migration-related job operations.
@@ -783,7 +783,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/job"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Default migration batch size.

--- a/docs/plans/2026-01-31-redis-streams-logging-impl.md
+++ b/docs/plans/2026-01-31-redis-streams-logging-impl.md
@@ -1017,8 +1017,8 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/north-cloud/crawler/internal/logs"
-	"github.com/north-cloud/infrastructure/sse"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/sse"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/docs/plans/2026-01-31-test-coverage-phase3-implementation.md
+++ b/docs/plans/2026-01-31-test-coverage-phase3-implementation.md
@@ -216,7 +216,7 @@ import (
 	"github.com/jonesrussell/north-cloud/auth/internal/api"
 	"github.com/jonesrussell/north-cloud/auth/internal/auth"
 	"github.com/jonesrussell/north-cloud/auth/internal/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 type mockLogger struct{}

--- a/docs/plans/2026-01-31-test-refactor-phase2-implementation.md
+++ b/docs/plans/2026-01-31-test-refactor-phase2-implementation.md
@@ -192,7 +192,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jonesrussell/north-cloud/crawler/internal/events"
-	infraevents "github.com/north-cloud/infrastructure/events"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 func TestNoOpHandler_AllMethods_ReturnNil(t *testing.T) {

--- a/docs/plans/2026-02-01-http-replay-proxy-implementation.md
+++ b/docs/plans/2026-02-01-http-replay-proxy-implementation.md
@@ -31,7 +31,7 @@ cd nc-http-proxy
 
 Create `nc-http-proxy/go.mod`:
 ```go
-module github.com/north-cloud/nc-http-proxy
+module github.com/jonesrussell/north-cloud/nc-http-proxy
 
 go 1.24
 ```

--- a/docs/plans/2026-02-02-routing-v2-implementation.md
+++ b/docs/plans/2026-02-02-routing-v2-implementation.md
@@ -758,7 +758,7 @@ import (
     "time"
 
     "github.com/elastic/go-elasticsearch/v8"
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const classifiedContentSuffix = "_classified_content"
@@ -973,7 +973,7 @@ import (
     "github.com/jonesrussell/north-cloud/publisher/internal/database"
     "github.com/jonesrussell/north-cloud/publisher/internal/discovery"
     "github.com/jonesrussell/north-cloud/publisher/internal/models"
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
     "github.com/redis/go-redis/v9"
 )
 

--- a/docs/plans/2026-02-03-streetcode-implementation-plan.md
+++ b/docs/plans/2026-02-03-streetcode-implementation-plan.md
@@ -338,7 +338,7 @@ import (
 
     "github.com/jonesrussell/north-cloud/classifier/internal/domain"
     "github.com/jonesrussell/north-cloud/classifier/internal/mlclient"
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // StreetCode classification thresholds
@@ -699,7 +699,7 @@ import (
     "encoding/json"
     "fmt"
 
-    infralogger "github.com/north-cloud/infrastructure/logger"
+    infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
     "github.com/redis/go-redis/v9"
 )
 

--- a/docs/plans/2026-02-03-streetcode-implementation-tasks.md
+++ b/docs/plans/2026-02-03-streetcode-implementation-tasks.md
@@ -1480,7 +1480,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
 	"github.com/jonesrussell/north-cloud/classifier/internal/mlclient"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // StreetCode classification thresholds.

--- a/docs/plans/2026-02-04-index-manager-dashboard-implementation.md
+++ b/docs/plans/2026-02-04-index-manager-dashboard-implementation.md
@@ -1110,7 +1110,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/index-manager/internal/domain"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/docs/plans/2026-02-08-coforge-ml-implementation.md
+++ b/docs/plans/2026-02-08-coforge-ml-implementation.md
@@ -1653,7 +1653,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/coforgemlclient"
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const coforgeMaxBodyChars = 500

--- a/docs/plans/2026-02-10-pipeline-service-implementation.md
+++ b/docs/plans/2026-02-10-pipeline-service-implementation.md
@@ -36,11 +36,11 @@ go 1.25
 require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/lib/pq v1.11.0
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 	github.com/stretchr/testify v1.11.1
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 3: Download dependencies**
@@ -72,7 +72,7 @@ package config
 import (
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 const (
@@ -1728,7 +1728,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
 )
 
 // SetupRoutes configures all API routes.
@@ -1755,8 +1755,8 @@ import (
 	"fmt"
 
 	"github.com/jonesrussell/north-cloud/pipeline/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // LoadConfig loads and validates the service configuration.
@@ -1842,8 +1842,8 @@ import (
 	"github.com/jonesrussell/north-cloud/pipeline/internal/config"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/database"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/service"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (
@@ -1897,8 +1897,8 @@ package bootstrap
 import (
 	"fmt"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 // Start initializes and runs the pipeline service.

--- a/docs/plans/2026-02-12-pipeline-integration-implementation.md
+++ b/docs/plans/2026-02-12-pipeline-integration-implementation.md
@@ -25,7 +25,7 @@ In `crawler/internal/content/rawcontent/service.go`, add `pipeline *pipeline.Cli
 
 ```go
 // Add import
-"github.com/north-cloud/infrastructure/pipeline"
+"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 
 // Add field to RawContentService struct (after rawIndexer)
 pipeline *pipeline.Client
@@ -88,7 +88,7 @@ Add `PipelineClient *pipeline.Client` field to `CrawlerParams` struct (after `DB
 PipelineClient *pipeline.Client // Pipeline observability client (optional)
 ```
 
-Add import: `"github.com/north-cloud/infrastructure/pipeline"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/pipeline"`
 
 Update the `NewCrawlerWithParams` call to `NewRawContentService` (line 56-60):
 
@@ -150,7 +150,7 @@ Find the `Config` struct implementation file. Add a `PipelineURL` field with env
 
 In `crawler/internal/bootstrap/services.go`, update `createCrawler()` (line 243-265):
 
-Add import: `"github.com/north-cloud/infrastructure/pipeline"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/pipeline"`
 
 Before the `crawler.NewCrawlerWithParams()` call, create the client:
 
@@ -203,7 +203,7 @@ git commit -m "feat(crawler): wire pipeline client through bootstrap config"
 
 In `classifier/internal/processor/poller.go`:
 
-Add import: `"github.com/north-cloud/infrastructure/pipeline"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/pipeline"`
 
 Add field to `Poller` struct (after `logger`):
 
@@ -308,7 +308,7 @@ PipelineURL string `env:"PIPELINE_URL" yaml:"pipeline_url"`
 
 In `classifier/cmd/processor/processor.go`:
 
-Add import: `"github.com/north-cloud/infrastructure/pipeline"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/pipeline"`
 
 Add to `ProcessorConfig` struct:
 
@@ -370,7 +370,7 @@ git commit -m "feat(classifier): wire pipeline client through processor config"
 
 In `publisher/internal/router/service.go`:
 
-Add import: `"github.com/north-cloud/infrastructure/pipeline"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/pipeline"`
 
 Add field to `Service` struct (after `lastSort`):
 
@@ -535,7 +535,7 @@ Actually, the cleanest pattern matching the existing code is to add `PipelineURL
 
 In `publisher/cmd_router.go`, in `runRouterWithStop()`:
 
-Add import: `"github.com/north-cloud/infrastructure/pipeline"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/pipeline"`
 
 After loading config (line 58), create the client:
 

--- a/docs/plans/2026-02-16-ml-sidecar-observability-implementation.md
+++ b/docs/plans/2026-02-16-ml-sidecar-observability-implementation.md
@@ -892,7 +892,7 @@ func (c *Classifier) logSidecarError(
 }
 ```
 
-Add required import: `infralogger "github.com/north-cloud/infrastructure/logger"` to observability.go.
+Add required import: `infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"` to observability.go.
 
 **Step 5: Extract ModelVersion from each result type for the success log**
 

--- a/docs/plans/2026-02-19-click-tracking-implementation.md
+++ b/docs/plans/2026-02-19-click-tracking-implementation.md
@@ -29,7 +29,7 @@ package clickurl_test
 import (
 	"testing"
 
-	"github.com/north-cloud/infrastructure/clickurl"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
 )
 
 func TestSign(t *testing.T) {
@@ -217,11 +217,11 @@ go 1.25
 
 require (
 	github.com/gin-gonic/gin v1.11.0
-	github.com/north-cloud/infrastructure v0.0.0-00010101000000-000000000000
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.9
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 Run: `cd click-tracker && go mod tidy`
@@ -236,7 +236,7 @@ import (
 	"fmt"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 const (
@@ -530,9 +530,9 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 func main() {
@@ -860,8 +860,8 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	"github.com/north-cloud/infrastructure/migration"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	"github.com/jonesrussell/north-cloud/infrastructure/migration"
 )
 
 func main() {
@@ -1011,7 +1011,7 @@ import (
 	"time"
 
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const insertBatchSize = 50
@@ -1207,8 +1207,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/storage"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const testSecret = "test-secret-key"
@@ -1348,8 +1348,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/domain"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/storage"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // ClickHandler handles click redirect requests.
@@ -1891,7 +1891,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/middleware"
-	"github.com/north-cloud/infrastructure/monitoring"
+	"github.com/jonesrussell/north-cloud/infrastructure/monitoring"
 )
 
 // SetupRoutes configures all API routes.
@@ -1925,8 +1925,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/config"
 	"github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (
@@ -1997,7 +1997,7 @@ Update imports in main.go to include:
 "github.com/jonesrussell/north-cloud/click-tracker/internal/api"
 "github.com/jonesrussell/north-cloud/click-tracker/internal/handler"
 "github.com/jonesrussell/north-cloud/click-tracker/internal/storage"
-"github.com/north-cloud/infrastructure/clickurl"
+"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
 ```
 
 **Step 4: Run build**
@@ -2143,7 +2143,7 @@ func generateQueryID() string {
 }
 ```
 
-Add imports: `"crypto/rand"`, `"encoding/hex"`, `"net/url"`, `"github.com/north-cloud/infrastructure/clickurl"`
+Add imports: `"crypto/rand"`, `"encoding/hex"`, `"net/url"`, `"github.com/jonesrussell/north-cloud/infrastructure/clickurl"`
 
 **Step 4: Update search main.go**
 
@@ -2165,7 +2165,7 @@ func runServer(cfg *config.Config, esClient *elasticsearch.Client, log infralogg
 }
 ```
 
-Add import: `"github.com/north-cloud/infrastructure/clickurl"`
+Add import: `"github.com/jonesrussell/north-cloud/infrastructure/clickurl"`
 
 **Step 5: Update search config.yml.example**
 

--- a/docs/plans/2026-02-20-idiomatic-go-workspaces.md
+++ b/docs/plans/2026-02-20-idiomatic-go-workspaces.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the hybrid go.work + replace-directives + GOWORK=off pattern with idiomatic Go workspace usage: go.work resolves cross-module deps, replace directives removed, GOWORK enabled everywhere.
 
-**Architecture:** Go workspaces were designed to eliminate `replace` directives for local multi-module repos. Currently every service has both a `replace github.com/north-cloud/infrastructure => ../infrastructure` directive AND a `GOWORK=off` env that prevents the workspace from being used — making go.work dead weight. The fix: remove replace directives (workspace handles resolution), remove GOWORK=off (workspace is now active), keep the golangci-lint-action CI step GOWORK=off-isolated (it runs from repo root which has no module).
+**Architecture:** Go workspaces were designed to eliminate `replace` directives for local multi-module repos. Currently every service has both a `replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure` directive AND a `GOWORK=off` env that prevents the workspace from being used — making go.work dead weight. The fix: remove replace directives (workspace handles resolution), remove GOWORK=off (workspace is now active), keep the golangci-lint-action CI step GOWORK=off-isolated (it runs from repo root which has no module).
 
 **Tech Stack:** Go 1.26+, go.work (workspace), golangci-lint, Taskfile, GitHub Actions
 
@@ -12,7 +12,7 @@
 
 ## Services with replace directives to remove
 
-Nine services have `replace github.com/north-cloud/infrastructure => ../infrastructure`:
+Nine services have `replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure`:
 `auth`, `classifier`, `click-tracker`, `index-manager`, `mcp-north-cloud`, `pipeline`, `publisher`, `search`, `source-manager`
 
 One service (`crawler`) also replaces `github.com/jonesrussell/north-cloud/index-manager => ../index-manager`.
@@ -31,7 +31,7 @@ Eleven service Taskfiles have `GOWORK: "off"` at line 13:
 
 Find and delete this line:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy to verify**
@@ -66,7 +66,7 @@ git commit -m "chore(auth): remove infrastructure replace directive (use workspa
 
 Find and delete this line from `classifier/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -100,7 +100,7 @@ git commit -m "chore(classifier): remove infrastructure replace directive (use w
 
 Delete from `click-tracker/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -135,7 +135,7 @@ The crawler has a multi-line replace block (around line 27):
 ```
 replace (
 	github.com/jonesrussell/north-cloud/index-manager => ../index-manager
-	github.com/north-cloud/infrastructure => ../infrastructure
+	github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 )
 ```
 Delete the entire block (both entries are workspace modules listed in go.work).
@@ -170,7 +170,7 @@ git commit -m "chore(crawler): remove workspace replace directives (use workspac
 
 Delete from `index-manager/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -203,7 +203,7 @@ git commit -m "chore(index-manager): remove infrastructure replace directive (us
 
 Delete from `mcp-north-cloud/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -236,7 +236,7 @@ git commit -m "chore(mcp-north-cloud): remove infrastructure replace directive (
 
 Delete from `pipeline/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -269,7 +269,7 @@ git commit -m "chore(pipeline): remove infrastructure replace directive (use wor
 
 Delete from `publisher/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -302,7 +302,7 @@ git commit -m "chore(publisher): remove infrastructure replace directive (use wo
 
 Delete from `search/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**
@@ -335,7 +335,7 @@ git commit -m "chore(search): remove infrastructure replace directive (use works
 
 Delete from `source-manager/go.mod`:
 ```
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 **Step 2: Run go mod tidy**

--- a/docs/plans/2026-02-26-discovered-domains-implementation.md
+++ b/docs/plans/2026-02-26-discovered-domains-implementation.md
@@ -790,7 +790,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/docs/plans/2026-02-26-discovered-domains-test-coverage.md
+++ b/docs/plans/2026-02-26-discovered-domains-test-coverage.md
@@ -855,7 +855,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // --- Mock types ---
@@ -1103,7 +1103,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 ```
 

--- a/docs/plans/2026-03-01-social-publisher-backend-additions-impl.md
+++ b/docs/plans/2026-03-01-social-publisher-backend-additions-impl.md
@@ -99,8 +99,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/orchestrator"
@@ -1049,7 +1049,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/api"
 	"github.com/stretchr/testify/assert"
 )
@@ -1120,7 +1120,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/crypto"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"

--- a/docs/plans/2026-03-01-social-publisher-phase1.md
+++ b/docs/plans/2026-03-01-social-publisher-phase1.md
@@ -150,7 +150,7 @@ package config
 import (
 	"fmt"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 type Config struct {
@@ -992,7 +992,7 @@ import (
 
 	goredis "github.com/redis/go-redis/v9"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/north-cloud/social-publisher/internal/domain"
 )
 
@@ -1049,7 +1049,7 @@ import (
 
 	goredis "github.com/redis/go-redis/v9"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/north-cloud/social-publisher/internal/domain"
 )
 
@@ -1864,7 +1864,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/north-cloud/social-publisher/internal/database"
 	"github.com/north-cloud/social-publisher/internal/domain"
 	"github.com/north-cloud/social-publisher/internal/orchestrator"
@@ -2047,7 +2047,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/north-cloud/social-publisher/internal/database"
 	"github.com/north-cloud/social-publisher/internal/domain"
 	"github.com/north-cloud/social-publisher/internal/orchestrator"
@@ -2346,8 +2346,8 @@ package api
 import (
 	"github.com/gin-gonic/gin"
 
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/north-cloud/social-publisher/internal/config"
 	"github.com/north-cloud/social-publisher/internal/database"
 )
@@ -2424,9 +2424,9 @@ import (
 
 	goredis "github.com/redis/go-redis/v9"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 
 	"github.com/north-cloud/social-publisher/internal/api"
 	"github.com/north-cloud/social-publisher/internal/config"

--- a/docs/plans/2026-03-02-rfp-pipeline-implementation.md
+++ b/docs/plans/2026-03-02-rfp-pipeline-implementation.md
@@ -243,7 +243,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // rfpKeywords are phrases whose presence (case-insensitive) strongly
@@ -420,7 +420,7 @@ import (
 	"strings"
 
 	"github.com/jonesrussell/north-cloud/classifier/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // RFP extractor constants.

--- a/docs/plans/2026-03-07-ai-observer-implementation.md
+++ b/docs/plans/2026-03-07-ai-observer-implementation.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Multi-category polling observer. Each poll cycle runs category passes in parallel behind a shared token-budget mutex. V0 ships the classifier drift category only (reads `*_classified_content` ES indices). Sidecar and ingestion categories are stubbed for future implementation.
 
-**Tech Stack:** Go 1.26, `github.com/anthropic-ai/anthropic-go-sdk`, `github.com/north-cloud/infrastructure` (config, logger, elasticsearch), `github.com/elastic/go-elasticsearch/v8`
+**Tech Stack:** Go 1.26, `github.com/anthropic-ai/anthropic-go-sdk`, `github.com/jonesrussell/north-cloud/infrastructure` (config, logger, elasticsearch), `github.com/elastic/go-elasticsearch/v8`
 
 **V0 scope note:** No operational Redis Streams for classifier/sidecar events exist yet — only source lifecycle events. No Loki query client exists in infrastructure. V0 delivers: service scaffold + classifier drift category (ES-based) + provider interface + cost-ceiling mutex + `ai_insights` ES index.
 
@@ -38,10 +38,10 @@ go 1.26
 require (
 	github.com/anthropic-ai/anthropic-go-sdk v0.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.3
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 Run: `cd ai-observer && go mod tidy` — this resolves the actual latest version of `anthropic-go-sdk`. If the module path is wrong, check https://pkg.go.dev/github.com/anthropic-ai/anthropic-go-sdk for the correct path.
@@ -291,7 +291,7 @@ func LoadConfig() (Config, error) {
 package bootstrap
 
 import (
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // CreateLogger initializes the structured logger.
@@ -317,7 +317,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Start initializes and runs the ai-observer service.
@@ -1236,7 +1236,7 @@ import (
 	"sync"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/category"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/insights"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/provider"
@@ -1447,7 +1447,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/north-cloud/infrastructure/elasticsearch"
+	"github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
 )
 
 // SetupElasticsearch creates and verifies the ES client.
@@ -1483,7 +1483,7 @@ import (
 	"syscall"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	classifiercategory "github.com/jonesrussell/north-cloud/ai-observer/internal/category/classifier"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/insights"
 	anthprovider "github.com/jonesrussell/north-cloud/ai-observer/internal/provider/anthropic"

--- a/docs/specs/shared-infrastructure.md
+++ b/docs/specs/shared-infrastructure.md
@@ -156,15 +156,15 @@ type LoggingConfig struct {
 
 ### Import Conventions
 ```go
-import infralogger "github.com/north-cloud/infrastructure/logger"
-import infraconfig "github.com/north-cloud/infrastructure/config"
+import infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+import infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 ```
 
 ### go.mod Pattern
 ```
 module github.com/jonesrussell/north-cloud/{service}
-require github.com/north-cloud/infrastructure v0.0.0
-replace github.com/north-cloud/infrastructure => ../infrastructure
+require github.com/jonesrussell/north-cloud/infrastructure v0.0.0
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure
 ```
 
 ## Edge Cases

--- a/index-manager/go.mod
+++ b/index-manager/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.19.3
 	github.com/gin-gonic/gin v1.11.0
 	github.com/lib/pq v1.11.2
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -56,4 +56,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/index-manager/internal/api/handlers.go
+++ b/index-manager/internal/api/handlers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/domain"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/service"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const errDocumentNotFound = "document not found"

--- a/index-manager/internal/api/server.go
+++ b/index-manager/internal/api/server.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Default timeout values.

--- a/index-manager/internal/bootstrap/app.go
+++ b/index-manager/internal/bootstrap/app.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 // Start initializes and starts the index-manager application.

--- a/index-manager/internal/bootstrap/config.go
+++ b/index-manager/internal/bootstrap/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/jonesrussell/north-cloud/index-manager/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // LoadConfig loads and validates configuration.

--- a/index-manager/internal/bootstrap/elasticsearch.go
+++ b/index-manager/internal/bootstrap/elasticsearch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jonesrussell/north-cloud/index-manager/internal/database"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch/mappings"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SetupElasticsearch creates an Elasticsearch client.

--- a/index-manager/internal/bootstrap/server.go
+++ b/index-manager/internal/bootstrap/server.go
@@ -8,8 +8,8 @@ import (
 	"github.com/jonesrussell/north-cloud/index-manager/internal/database"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/service"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const httpTimeoutSeconds = 15

--- a/index-manager/internal/config/config.go
+++ b/index-manager/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default configuration values.

--- a/index-manager/internal/elasticsearch/client.go
+++ b/index-manager/internal/elasticsearch/client.go
@@ -14,8 +14,8 @@ import (
 
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	"github.com/north-cloud/infrastructure/logger"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const unknownStatus = "unknown"

--- a/index-manager/internal/service/aggregation_service.go
+++ b/index-manager/internal/service/aggregation_service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/index-manager/internal/domain"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/index-manager/internal/service/aggregation_service_test.go
+++ b/index-manager/internal/service/aggregation_service_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // --- mock ES client ---

--- a/index-manager/internal/service/document_service.go
+++ b/index-manager/internal/service/document_service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/jonesrussell/north-cloud/index-manager/internal/domain"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // DocumentService provides business logic for document operations

--- a/index-manager/internal/service/index_service.go
+++ b/index-manager/internal/service/index_service.go
@@ -16,8 +16,8 @@ import (
 	"github.com/jonesrussell/north-cloud/index-manager/internal/domain"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch"
 	"github.com/jonesrussell/north-cloud/index-manager/internal/elasticsearch/mappings"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/naming"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/naming"
 )
 
 // IndexService provides business logic for index operations

--- a/infrastructure/clickurl/signer_test.go
+++ b/infrastructure/clickurl/signer_test.go
@@ -3,7 +3,7 @@ package clickurl_test
 import (
 	"testing"
 
-	"github.com/north-cloud/infrastructure/clickurl"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
 )
 
 const testSecret = "test-secret-key-for-hmac-signing"

--- a/infrastructure/elasticsearch/client.go
+++ b/infrastructure/elasticsearch/client.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	es "github.com/elastic/go-elasticsearch/v8"
-	"github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/retry"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/retry"
 )
 
 // NewClient creates a new Elasticsearch client with retry logic for connection verification.

--- a/infrastructure/elasticsearch/client_test.go
+++ b/infrastructure/elasticsearch/client_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/retry"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/retry"
 )
 
 func TestNormalizeURL(t *testing.T) {

--- a/infrastructure/elasticsearch/config.go
+++ b/infrastructure/elasticsearch/config.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"time"
 
-	"github.com/north-cloud/infrastructure/retry"
+	"github.com/jonesrussell/north-cloud/infrastructure/retry"
 )
 
 // Config holds Elasticsearch client configuration

--- a/infrastructure/events/types_test.go
+++ b/infrastructure/events/types_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/north-cloud/infrastructure/events"
+	"github.com/jonesrussell/north-cloud/infrastructure/events"
 )
 
 func TestSourceEvent_MarshalJSON(t *testing.T) {

--- a/infrastructure/gin/builder.go
+++ b/infrastructure/gin/builder.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/north-cloud/infrastructure/jwt"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/jwt"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // ServerBuilder provides a fluent API for building HTTP servers.

--- a/infrastructure/gin/health.go
+++ b/infrastructure/gin/health.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/north-cloud/infrastructure/monitoring"
+	"github.com/jonesrussell/north-cloud/infrastructure/monitoring"
 )
 
 // HealthStatus represents the status of a health check.

--- a/infrastructure/gin/internal_auth_test.go
+++ b/infrastructure/gin/internal_auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	ginpkg "github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
 )
 
 func TestInternalAuthMiddleware_RejectsMissingHeader(t *testing.T) {

--- a/infrastructure/gin/middleware.go
+++ b/infrastructure/gin/middleware.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Buffer size constants for middleware operations.

--- a/infrastructure/gin/middleware_test.go
+++ b/infrastructure/gin/middleware_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	ginpkg "github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestRequestIDLoggerMiddleware_GeneratesID(t *testing.T) {

--- a/infrastructure/gin/server.go
+++ b/infrastructure/gin/server.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Server represents an HTTP server with lifecycle management.

--- a/infrastructure/go.mod
+++ b/infrastructure/go.mod
@@ -1,4 +1,4 @@
-module github.com/north-cloud/infrastructure
+module github.com/jonesrussell/north-cloud/infrastructure
 
 go 1.26
 

--- a/infrastructure/logger/context_test.go
+++ b/infrastructure/logger/context_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestWithContext_FromContext_RoundTrip(t *testing.T) {

--- a/infrastructure/pipeline/client_test.go
+++ b/infrastructure/pipeline/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/north-cloud/infrastructure/pipeline"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 )
 
 func TestClient_Emit_Success(t *testing.T) {

--- a/infrastructure/redis/client_test.go
+++ b/infrastructure/redis/client_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/north-cloud/infrastructure/redis"
+	"github.com/jonesrussell/north-cloud/infrastructure/redis"
 )
 
 func TestNewClient_ReturnsNilWhenAddressEmpty(t *testing.T) {

--- a/infrastructure/sse/broker.go
+++ b/infrastructure/sse/broker.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // broker implements the Broker interface.

--- a/infrastructure/sse/broker_test.go
+++ b/infrastructure/sse/broker_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func newTestLogger(t *testing.T) infralogger.Logger {

--- a/infrastructure/sse/middleware.go
+++ b/infrastructure/sse/middleware.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // SSE header constants.

--- a/mcp-north-cloud/go.mod
+++ b/mcp-north-cloud/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -21,4 +21,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/mcp-north-cloud/internal/config/config.go
+++ b/mcp-north-cloud/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // defaultURLPublisherClassifier is the default base URL for publisher and classifier (same port in dev).

--- a/mcp-north-cloud/internal/mcp/audit.go
+++ b/mcp-north-cloud/internal/mcp/audit.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // AuditEntry captures metrics for a single tool invocation.

--- a/mcp-north-cloud/internal/mcp/server.go
+++ b/mcp-north-cloud/internal/mcp/server.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/mcp-north-cloud/internal/client"
-	"github.com/north-cloud/infrastructure/logger"
 )
 
 // Server handles MCP protocol requests

--- a/mcp-north-cloud/main.go
+++ b/mcp-north-cloud/main.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"time"
 
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/mcp-north-cloud/internal/client"
 	"github.com/jonesrussell/north-cloud/mcp-north-cloud/internal/config"
 	"github.com/jonesrussell/north-cloud/mcp-north-cloud/internal/mcp"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	"github.com/north-cloud/infrastructure/logger"
 )
 
 func main() {

--- a/nc-http-proxy/go.mod
+++ b/nc-http-proxy/go.mod
@@ -1,3 +1,3 @@
-module github.com/north-cloud/nc-http-proxy
+module github.com/jonesrussell/north-cloud/nc-http-proxy
 
 go 1.26

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/gin-gonic/gin v1.11.0
 	github.com/lib/pq v1.11.2
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -48,4 +48,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/pipeline/internal/api/routes.go
+++ b/pipeline/internal/api/routes.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
 )
 
 // SetupRoutes configures all API routes.

--- a/pipeline/internal/bootstrap/app.go
+++ b/pipeline/internal/bootstrap/app.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 // Start initializes and runs the pipeline service.

--- a/pipeline/internal/bootstrap/config.go
+++ b/pipeline/internal/bootstrap/config.go
@@ -3,9 +3,9 @@ package bootstrap
 import (
 	"fmt"
 
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // LoadConfig loads and validates the service configuration.

--- a/pipeline/internal/bootstrap/server.go
+++ b/pipeline/internal/bootstrap/server.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/api"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/config"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/database"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/service"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/pipeline/internal/config/config.go
+++ b/pipeline/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default service configuration values.

--- a/pipeline/internal/service/pipeline.go
+++ b/pipeline/internal/service/pipeline.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const maxEventAge = 24 * time.Hour

--- a/pipeline/internal/service/pipeline_test.go
+++ b/pipeline/internal/service/pipeline_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/pipeline/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 type mockRepository struct {

--- a/publisher/cmd/api/main.go
+++ b/publisher/cmd/api/main.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/jmoiron/sqlx"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 	"github.com/jonesrussell/north-cloud/publisher/internal/api"
 	"github.com/jonesrussell/north-cloud/publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
 	redisclient "github.com/jonesrussell/north-cloud/publisher/internal/redis"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/cmd/router/clients.go
+++ b/publisher/cmd/router/clients.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/elastic/go-elasticsearch/v8"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	"github.com/north-cloud/infrastructure/logger"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/cmd/router/config.go
+++ b/publisher/cmd/router/config.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
-	infraconfig "github.com/north-cloud/infrastructure/config"
 )
 
 const (

--- a/publisher/cmd/router/main.go
+++ b/publisher/cmd/router/main.go
@@ -9,12 +9,12 @@ import (
 	"syscall"
 	"time"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/publisher/internal/discovery"
 	"github.com/jonesrussell/north-cloud/publisher/internal/router"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
-	"github.com/north-cloud/infrastructure/profiling"
 )
 
 const (

--- a/publisher/cmd_api.go
+++ b/publisher/cmd_api.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/publisher/internal/api"
 	"github.com/jonesrussell/north-cloud/publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
 	redisclient "github.com/jonesrussell/north-cloud/publisher/internal/redis"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/cmd_router.go
+++ b/publisher/cmd_router.go
@@ -9,13 +9,13 @@ import (
 	"syscall"
 	"time"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/publisher/internal/discovery"
 	"github.com/jonesrussell/north-cloud/publisher/internal/router"
 	"github.com/jonesrussell/north-cloud/publisher/internal/telemetry"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
-	"github.com/north-cloud/infrastructure/profiling"
 )
 
 func runRouter() {

--- a/publisher/go.mod
+++ b/publisher/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.2
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/stretchr/testify v1.11.1
@@ -72,4 +72,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/publisher/internal/api/handlers.go
+++ b/publisher/internal/api/handlers.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Handlers provides HTTP handlers for the API

--- a/publisher/internal/api/router.go
+++ b/publisher/internal/api/router.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/gin-gonic/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 )

--- a/publisher/internal/api/stats_service.go
+++ b/publisher/internal/api/stats_service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/publisher/internal/metrics"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const defaultLimit = 50

--- a/publisher/internal/config/config.go
+++ b/publisher/internal/config/config.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infracontext "github.com/north-cloud/infrastructure/context"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infracontext "github.com/jonesrussell/north-cloud/infrastructure/context"
 )
 
 const (

--- a/publisher/internal/config/config_test.go
+++ b/publisher/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 func TestConfigDebugFromEnv(t *testing.T) {

--- a/publisher/internal/dedup/tracker.go
+++ b/publisher/internal/dedup/tracker.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/internal/discovery/discovery.go
+++ b/publisher/internal/discovery/discovery.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const classifiedContentSuffix = "_classified_content"

--- a/publisher/internal/metrics/tracker.go
+++ b/publisher/internal/metrics/tracker.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/internal/router/service.go
+++ b/publisher/internal/router/service.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/google/uuid"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/pipeline"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/publisher/internal/discovery"
 	"github.com/jonesrussell/north-cloud/publisher/internal/models"
 	"github.com/jonesrussell/north-cloud/publisher/internal/telemetry"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/pipeline"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/internal/sources/client.go
+++ b/publisher/internal/sources/client.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"time"
 
+	infrahttp "github.com/jonesrussell/north-cloud/infrastructure/http"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/publisher/internal/config"
-	infrahttp "github.com/north-cloud/infrastructure/http"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 type Client struct {

--- a/publisher/internal/worker/outbox_worker.go
+++ b/publisher/internal/worker/outbox_worker.go
@@ -14,9 +14,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/publisher/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 var (

--- a/publisher/router_clients.go
+++ b/publisher/router_clients.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/elastic/go-elasticsearch/v8"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	"github.com/north-cloud/infrastructure/logger"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/publisher/router_config.go
+++ b/publisher/router_config.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/publisher/internal/database"
-	infraconfig "github.com/north-cloud/infrastructure/config"
 )
 
 const (

--- a/rfp-ingestor/go.mod
+++ b/rfp-ingestor/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/gin-gonic/gin v1.11.0
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -43,4 +43,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/rfp-ingestor/internal/api/server.go
+++ b/rfp-ingestor/internal/api/server.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Status tracks the outcome of the most recent ingestion cycle.

--- a/rfp-ingestor/internal/config/config.go
+++ b/rfp-ingestor/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default configuration values.

--- a/rfp-ingestor/internal/ingestor/ingestor.go
+++ b/rfp-ingestor/internal/ingestor/ingestor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jonesrussell/north-cloud/rfp-ingestor/internal/domain"
 	esindex "github.com/jonesrussell/north-cloud/rfp-ingestor/internal/elasticsearch"
 	"github.com/jonesrussell/north-cloud/rfp-ingestor/internal/feed"
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Config holds the settings needed to run a single ingestion cycle.

--- a/rfp-ingestor/internal/ingestor/ingestor_test.go
+++ b/rfp-ingestor/internal/ingestor/ingestor_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func TestIngestor_RunOnce(t *testing.T) {

--- a/rfp-ingestor/main.go
+++ b/rfp-ingestor/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/jonesrussell/north-cloud/rfp-ingestor/internal/config"
 	esindex "github.com/jonesrussell/north-cloud/rfp-ingestor/internal/elasticsearch"
 	"github.com/jonesrussell/north-cloud/rfp-ingestor/internal/ingestor"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	"github.com/north-cloud/infrastructure/logger"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 func main() {

--- a/search/go.mod
+++ b/search/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.19.3
 	github.com/gin-gonic/gin v1.11.0
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 )
 
 require (
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/search/internal/api/handlers.go
+++ b/search/internal/api/handlers.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/search/internal/domain"
 	"github.com/jonesrussell/north-cloud/search/internal/service"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const trueString = "true"

--- a/search/internal/api/middleware.go
+++ b/search/internal/api/middleware.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/search/internal/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/search/internal/api/routes.go
+++ b/search/internal/api/routes.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/north-cloud/infrastructure/monitoring"
+	"github.com/jonesrussell/north-cloud/infrastructure/monitoring"
 )
 
 // SetupRoutes configures all API routes

--- a/search/internal/api/server.go
+++ b/search/internal/api/server.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/search/internal/config"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // Default timeout values.

--- a/search/internal/config/config.go
+++ b/search/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 // Default configuration values.

--- a/search/internal/elasticsearch/client.go
+++ b/search/internal/elasticsearch/client.go
@@ -8,9 +8,9 @@ import (
 
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
+	esclient "github.com/jonesrussell/north-cloud/infrastructure/elasticsearch"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/search/internal/config"
-	esclient "github.com/north-cloud/infrastructure/elasticsearch"
-	"github.com/north-cloud/infrastructure/logger"
 )
 
 // Client wraps the Elasticsearch client

--- a/search/internal/service/search_service.go
+++ b/search/internal/service/search_service.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/search/internal/config"
 	"github.com/jonesrussell/north-cloud/search/internal/domain"
 	"github.com/jonesrussell/north-cloud/search/internal/elasticsearch"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // SearchService orchestrates search operations

--- a/search/main.go
+++ b/search/main.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jonesrussell/north-cloud/infrastructure/clickurl"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 	"github.com/jonesrussell/north-cloud/search/internal/api"
 	"github.com/jonesrussell/north-cloud/search/internal/config"
 	"github.com/jonesrussell/north-cloud/search/internal/elasticsearch"
 	"github.com/jonesrussell/north-cloud/search/internal/service"
-	"github.com/north-cloud/infrastructure/clickurl"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
 )
 
 func main() {

--- a/social-publisher/go.mod
+++ b/social-publisher/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.2
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/stretchr/testify v1.11.1
 )
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/social-publisher/internal/api/accounts_handler.go
+++ b/social-publisher/internal/api/accounts_handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/crypto"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // AccountsHandler implements account management endpoints.

--- a/social-publisher/internal/api/accounts_handler_test.go
+++ b/social-publisher/internal/api/accounts_handler_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/api"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/social-publisher/internal/api/handler.go
+++ b/social-publisher/internal/api/handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/orchestrator"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/social-publisher/internal/api/handler_test.go
+++ b/social-publisher/internal/api/handler_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/api"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/social-publisher/internal/api/router.go
+++ b/social-publisher/internal/api/router.go
@@ -8,8 +8,8 @@ import (
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/config"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/orchestrator"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	"github.com/north-cloud/infrastructure/logger"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // Router wires API routes to the infrastructure HTTP server.

--- a/social-publisher/internal/config/config.go
+++ b/social-publisher/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 const requiredEncryptionKeyHexLen = 64 // 32 bytes as hex

--- a/social-publisher/internal/redis/publisher.go
+++ b/social-publisher/internal/redis/publisher.go
@@ -7,7 +7,7 @@ import (
 
 	goredis "github.com/redis/go-redis/v9"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"
 )
 

--- a/social-publisher/internal/redis/subscriber.go
+++ b/social-publisher/internal/redis/subscriber.go
@@ -7,7 +7,7 @@ import (
 
 	goredis "github.com/redis/go-redis/v9"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"
 )
 

--- a/social-publisher/internal/workers/retry.go
+++ b/social-publisher/internal/workers/retry.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/orchestrator"

--- a/social-publisher/internal/workers/scheduler.go
+++ b/social-publisher/internal/workers/scheduler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/database"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/domain"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/orchestrator"

--- a/social-publisher/main.go
+++ b/social-publisher/main.go
@@ -14,8 +14,8 @@ import (
 	_ "github.com/lib/pq"
 	goredis "github.com/redis/go-redis/v9"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 
 	xadapter "github.com/jonesrussell/north-cloud/social-publisher/internal/adapters/x"
 	"github.com/jonesrussell/north-cloud/social-publisher/internal/api"

--- a/source-manager/go.mod
+++ b/source-manager/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.11.2
-	github.com/north-cloud/infrastructure v0.0.0
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.10.0
@@ -62,4 +62,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/north-cloud/infrastructure => ../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../infrastructure

--- a/source-manager/internal/api/router.go
+++ b/source-manager/internal/api/router.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/config"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/events"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/handlers"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/repository"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // Constants for router configuration.

--- a/source-manager/internal/bootstrap/app.go
+++ b/source-manager/internal/bootstrap/app.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/profiling"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/profiling"
 )
 
 const version = "dev"

--- a/source-manager/internal/bootstrap/config.go
+++ b/source-manager/internal/bootstrap/config.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/config"
-	infraconfig "github.com/north-cloud/infrastructure/config"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // LoadConfig loads configuration. Uses -config flag with infraconfig default.

--- a/source-manager/internal/bootstrap/database.go
+++ b/source-manager/internal/bootstrap/database.go
@@ -3,9 +3,9 @@ package bootstrap
 import (
 	"fmt"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/config"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/database"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // SetupDatabase creates a database connection.

--- a/source-manager/internal/bootstrap/redis.go
+++ b/source-manager/internal/bootstrap/redis.go
@@ -1,10 +1,10 @@
 package bootstrap
 
 import (
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	infraredis "github.com/jonesrussell/north-cloud/infrastructure/redis"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/config"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	infraredis "github.com/north-cloud/infrastructure/redis"
 )
 
 // SetupEventPublisher creates an optional event publisher if Redis is enabled.

--- a/source-manager/internal/bootstrap/server.go
+++ b/source-manager/internal/bootstrap/server.go
@@ -1,13 +1,13 @@
 package bootstrap
 
 import (
+	infragin "github.com/jonesrussell/north-cloud/infrastructure/gin"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/api"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/config"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/database"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/events"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/repository"
-	infragin "github.com/north-cloud/infrastructure/gin"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // SetupHTTPServer creates and configures the HTTP server.

--- a/source-manager/internal/config/config.go
+++ b/source-manager/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	infraconfig "github.com/north-cloud/infrastructure/config"
+	infraconfig "github.com/jonesrussell/north-cloud/infrastructure/config"
 )
 
 const (

--- a/source-manager/internal/database/database.go
+++ b/source-manager/internal/database/database.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/retry"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/config"
 	_ "github.com/lib/pq" //nolint:blankimports // PostgreSQL driver
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/retry"
 )
 
 // Connection retry configuration

--- a/source-manager/internal/events/publisher.go
+++ b/source-manager/internal/events/publisher.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // asyncPublishTimeout is the context timeout for async publish operations.

--- a/source-manager/internal/handlers/source.go
+++ b/source-manager/internal/handlers/source.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	infraevents "github.com/jonesrussell/north-cloud/infrastructure/events"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/events"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/importer"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/metadata"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/repository"
 	"github.com/lib/pq"
-	infraevents "github.com/north-cloud/infrastructure/events"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/source-manager/internal/metadata/extractor.go
+++ b/source-manager/internal/metadata/extractor.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 const (

--- a/source-manager/internal/repository/source.go
+++ b/source-manager/internal/repository/source.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/infrastructure/naming"
 	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
-	infralogger "github.com/north-cloud/infrastructure/logger"
-	"github.com/north-cloud/infrastructure/naming"
 )
 
 type SourceRepository struct {

--- a/source-manager/internal/testhelpers/database.go
+++ b/source-manager/internal/testhelpers/database.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 	_ "github.com/lib/pq" //nolint:blankimports // PostgreSQL driver
-	infralogger "github.com/north-cloud/infrastructure/logger"
 )
 
 // TestDatabase provides helper functions for test database setup

--- a/source-manager/internal/testhelpers/logger.go
+++ b/source-manager/internal/testhelpers/logger.go
@@ -1,7 +1,7 @@
 package testhelpers
 
 import (
-	infralogger "github.com/north-cloud/infrastructure/logger"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
 )
 
 // NewTestLogger creates a logger suitable for testing (discards output by default)

--- a/tests/contracts/go.mod
+++ b/tests/contracts/go.mod
@@ -6,4 +6,4 @@ require github.com/jonesrussell/north-cloud/index-manager v0.0.0
 
 replace github.com/jonesrussell/north-cloud/index-manager => ../../index-manager
 
-replace github.com/north-cloud/infrastructure => ../../infrastructure
+replace github.com/jonesrussell/north-cloud/infrastructure => ../../infrastructure


### PR DESCRIPTION
## Summary
- Rename infrastructure module: `github.com/north-cloud/infrastructure` → `github.com/jonesrussell/north-cloud/infrastructure`
- Rename nc-http-proxy module: `github.com/north-cloud/nc-http-proxy` → `github.com/jonesrussell/north-cloud/nc-http-proxy`
- Update all 14 service go.mod require/replace directives
- Update all Go import statements across the codebase (241 .go files)
- Re-vendor all services
- Update documentation references in CLAUDE.md, specs, and plan docs

Closes #167

## Test plan
- [x] All 12 Go services pass linting with 0 issues (`golangci-lint run`)
- [x] All 12 Go services pass tests (`go test ./...`)
- [x] No remaining references to `github.com/north-cloud/infrastructure` or `github.com/north-cloud/nc-http-proxy` in code or go.mod files
- [ ] CI workflow passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)