### PR TITLE
D2: Indigenous Category Taxonomy Expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This project uses [Semantic Versioning](https://semver.org/).
   - Source-Manager: validates and normalizes `indigenous_region` on create/update
   - Crawler: normalizes region slug before writing to `meta.indigenous_region`
   - Publisher: uses shared `NormalizeRegionSlug` for region channel routing (handles mixed-case, hyphens, spaces)
+- **Indigenous Category Taxonomy Expansion (D2)** — expand from 6 to 10 global categories
+  - ML Sidecar: structured `CATEGORY_KEYWORDS` with per-language placeholder comments, `CATEGORY_COUNT` constant
+  - Go Classifier: category constants and `IndigenousCategories` slice for cross-referencing
+  - Publisher: tests for all 10 category routing channels
+  - Design doc: `docs/plans/2026-03-11-indigenous-category-taxonomy.md`
 
 ## [0.5.0] - 2026-03-08
 

--- a/classifier/internal/classifier/indigenous_rules.go
+++ b/classifier/internal/classifier/indigenous_rules.go
@@ -12,6 +12,39 @@ const (
 	indigenousRelevanceNot        = "not_indigenous"
 )
 
+// Indigenous category slugs — 10 global categories.
+// Category extraction is performed by the ML sidecar; these constants are for
+// cross-referencing and documentation. D2.1 will add category-specific regex arrays.
+const (
+	indigenousCategoryCulture     = "culture"
+	indigenousCategoryLanguage    = "language"
+	indigenousCategoryLandRights  = "land_rights"
+	indigenousCategoryEnvironment = "environment"
+	indigenousCategorySovereignty = "sovereignty"
+	indigenousCategoryEducation   = "education"
+	indigenousCategoryHealth      = "health"
+	indigenousCategoryJustice     = "justice"
+	indigenousCategoryHistory     = "history"
+	indigenousCategoryCommunity   = "community"
+)
+
+// indigenousCategoryCount is the total number of canonical indigenous categories.
+const indigenousCategoryCount = 10
+
+// IndigenousCategories lists all valid indigenous category slugs.
+var IndigenousCategories = []string{
+	indigenousCategoryCulture,
+	indigenousCategoryLanguage,
+	indigenousCategoryLandRights,
+	indigenousCategoryEnvironment,
+	indigenousCategorySovereignty,
+	indigenousCategoryEducation,
+	indigenousCategoryHealth,
+	indigenousCategoryJustice,
+	indigenousCategoryHistory,
+	indigenousCategoryCommunity,
+}
+
 const (
 	indigenousConfidenceCore       = 0.90
 	indigenousConfidencePeripheral = 0.70

--- a/classifier/internal/classifier/indigenous_rules_test.go
+++ b/classifier/internal/classifier/indigenous_rules_test.go
@@ -178,3 +178,32 @@ func TestIndigenousRules_BodyTruncation(t *testing.T) {
 		t.Errorf("expected not_indigenous when pattern is beyond truncation limit, got %s", result.relevance)
 	}
 }
+
+func TestIndigenousCategoryTaxonomy(t *testing.T) {
+	t.Helper()
+
+	if len(IndigenousCategories) != indigenousCategoryCount {
+		t.Errorf("expected %d categories, got %d", indigenousCategoryCount, len(IndigenousCategories))
+	}
+
+	expected := map[string]bool{
+		"culture": true, "language": true, "land_rights": true,
+		"environment": true, "sovereignty": true, "education": true,
+		"health": true, "justice": true, "history": true, "community": true,
+	}
+
+	for _, cat := range IndigenousCategories {
+		if !expected[cat] {
+			t.Errorf("unexpected category %q in IndigenousCategories", cat)
+		}
+	}
+
+	// Verify no duplicates
+	seen := make(map[string]bool, indigenousCategoryCount)
+	for _, cat := range IndigenousCategories {
+		if seen[cat] {
+			t.Errorf("duplicate category %q", cat)
+		}
+		seen[cat] = true
+	}
+}

--- a/docs/plans/2026-03-11-indigenous-category-taxonomy.md
+++ b/docs/plans/2026-03-11-indigenous-category-taxonomy.md
@@ -1,0 +1,74 @@
+# D2: Indigenous Category Taxonomy Expansion
+
+**Status**: Implemented
+**Date**: 2026-03-11
+**Depends on**: D0 (Global Indigenous Content Platform), D1 (Region Taxonomy Finalization)
+
+## Overview
+
+Expand the indigenous content category taxonomy from the original 6 Canada-centric categories to 10 globally applicable categories. This milestone defines the canonical category set, adds placeholder keyword arrays for future multilingual pattern population (D2.1), and ensures backward compatibility.
+
+## Canonical Categories (10)
+
+| Slug | Definition | Example content |
+|------|-----------|-----------------|
+| `culture` | Ceremonies, art, music, dance, traditional practices, cultural preservation | Powwow, corroboree, haka, dreamtime stories |
+| `language` | Language revitalization, education, documentation, endangered languages | Te Reo Māori revival, Anishinaabemowin immersion |
+| `land_rights` | Territory disputes, land claims, demarcation, resource rights | Terra indígena demarcation, treaty land entitlements |
+| `environment` | Climate, water rights, pipeline opposition, deforestation, conservation | Standing Rock, Amazon deforestation, water protectors |
+| `sovereignty` | Self-determination, governance, treaties, political autonomy | Band council resolutions, tribal sovereignty rulings |
+| `education` | Schools, residential school legacy, indigenous education programs | TRC recommendations, indigenous curriculum reform |
+| `health` | Indigenous health disparities, traditional medicine, mental health | Boil water advisories, traditional healing programs |
+| `justice` | MMIWG, incarceration, policing, legal rights, human rights | Missing and murdered inquiry, overrepresentation |
+| `history` | Colonial history, decolonization, historical events, reconciliation | Residential school discoveries, treaty signing dates |
+| `community` | Elders, youth, family, community events, social programs | Community gatherings, elder consultations, youth programs |
+
+## Backward Compatibility
+
+The original 6 categories (`anishinaabe`, `culture`, `language`, `governance`, `land_rights`, `education`) map to the new taxonomy:
+
+| Old category | New category | Notes |
+|-------------|-------------|-------|
+| `anishinaabe` | (removed) | Nation-specific; use `culture` + region instead |
+| `culture` | `culture` | Unchanged |
+| `language` | `language` | Unchanged |
+| `governance` | `sovereignty` | Renamed for global applicability |
+| `land_rights` | `land_rights` | Unchanged |
+| `education` | `education` | Unchanged |
+
+New categories added: `environment`, `health`, `justice`, `history`, `community`.
+
+Existing classified content with `governance` will continue to route correctly — the publisher converts categories to slugs dynamically and does not validate against a fixed list.
+
+## Classifier Mapping Rules
+
+### Python ML Sidecar (`relevance.py`)
+
+Each category has a keyword list in `CATEGORY_KEYWORDS`. Keywords are checked via substring match against lowercased text. The sidecar emits up to `MAX_CATEGORIES = 5` matched categories.
+
+Placeholder keyword arrays are defined for each category. Full multilingual keyword population is deferred to D2.1.
+
+### Go Classifier (`indigenous_rules.go`)
+
+The Go classifier does not perform category extraction — it only determines relevance (core/peripheral/not). Category assignment is the ML sidecar's responsibility. The Go rules file defines category constants for documentation and cross-referencing.
+
+## Multilingual Keyword Sets (D2.1)
+
+Each category will have keywords in 7 languages: English, Spanish, French, Portuguese, Nordic, Te Reo Māori, Japanese. D2 defines the category structure; D2.1 populates the keyword arrays with domain-expert-reviewed terms.
+
+## Publisher Routing
+
+The publisher's `IndigenousDomain.Routes()` already handles categories generically:
+
+```go
+slug := strings.ToLower(strings.ReplaceAll(cat, " ", "-"))
+channels = append(channels, "indigenous:category:"+slug)
+```
+
+No publisher code changes are needed — any category string from the classifier is automatically routed to `indigenous:category:{slug}`.
+
+## Future Extensions
+
+- **Hierarchical categories**: e.g., `culture/art`, `culture/ceremony` — not needed until content volume justifies it
+- **People-level categories**: e.g., `anishinaabe`, `maori`, `ainu` — consider as tags rather than categories to avoid combinatorial explosion
+- **Cross-category content**: A single article can match multiple categories (up to `MAX_CATEGORIES = 5`); no additional logic needed

--- a/ml-sidecars/indigenous-ml/classifier/relevance.py
+++ b/ml-sidecars/indigenous-ml/classifier/relevance.py
@@ -51,28 +51,74 @@ PERIPHERAL_PATTERNS = [
 ]
 
 # --- 10 global categories ---
+# Each tuple: (keyword_list, category_slug).
+# Keywords are matched as substrings against lowercased text.
+# D2.1 will expand each list with domain-expert-reviewed multilingual terms.
+CATEGORY_COUNT = 10
 CATEGORY_KEYWORDS: list[tuple[list[str], str]] = [
+    # Culture: ceremonies, art, music, dance, traditional practices
     (["culture", "ceremony", "powwow", "potlatch", "sweat lodge", "corroboree",
-      "haka", "dreamtime", "cultura"], "culture"),
+      "haka", "dreamtime",
+      "cultura", "ceremonia",  # Spanish
+      "cérémonie", "tradition",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "culture"),
+    # Language: revitalization, education, documentation, endangered languages
     (["language", "anishinaabemowin", "indigenous language", "cree", "inuktitut",
-      "te reo", "lengua indígena", "langue autochtone"], "language"),
+      "te reo",
+      "lengua indígena",  # Spanish
+      "langue autochtone",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "language"),
+    # Land rights: territory disputes, land claims, demarcation
     (["land rights", "territory", "reserve", "reservation", "land claim",
-      "terra indígena", "demarcação", "territorio ancestral"], "land_rights"),
+      "territorio ancestral",  # Spanish
+      "terra indígena", "demarcação",  # Portuguese
+      # French / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "land_rights"),
+    # Environment: climate, water rights, pipeline opposition, conservation
     (["environment", "climate", "water rights", "pipeline", "deforestation",
-      "medio ambiente", "environnement"], "environment"),
+      "medio ambiente",  # Spanish
+      "environnement",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "environment"),
+    # Sovereignty: self-determination, governance, treaties, political autonomy
     (["sovereignty", "self-determination", "self-governance", "treaty",
       "governance", "band council", "grand council",
-      "soberanía", "autodeterminación"], "sovereignty"),
+      "soberanía", "autodeterminación",  # Spanish
+      # French / Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "sovereignty"),
+    # Education: schools, residential school legacy, indigenous education programs
     (["education", "residential school", "indigenous education",
-      "educación", "éducation"], "education"),
+      "educación",  # Spanish
+      "éducation",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "education"),
+    # Health: indigenous health disparities, traditional medicine
     (["health", "indigenous health", "traditional medicine",
-      "salud indígena", "santé autochtone"], "health"),
+      "salud indígena",  # Spanish
+      "santé autochtone",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "health"),
+    # Justice: MMIWG, incarceration, policing, legal rights
     (["justice", "missing and murdered", "incarceration", "police",
-      "justicia", "justice autochtone"], "justice"),
+      "justicia",  # Spanish
+      "justice autochtone",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "justice"),
+    # History: colonial history, decolonization, historical events
     (["history", "colonial", "colonization", "decolonization",
-      "historia", "histoire", "colonisation"], "history"),
-    (["community", "elders", "youth", "whānau", "hapū",
-      "comunidad", "communauté"], "community"),
+      "historia",  # Spanish
+      "histoire", "colonisation",  # French
+      # Portuguese / Nordic / Te Reo / Japanese — D2.1 placeholder
+      ], "history"),
+    # Community: elders, youth, family, community events
+    (["community", "elders", "youth",
+      "whānau", "hapū",  # Te Reo
+      "comunidad",  # Spanish
+      "communauté",  # French
+      # Portuguese / Nordic / Japanese — D2.1 placeholder
+      ], "community"),
 ]
 
 

--- a/ml-sidecars/indigenous-ml/tests/test_relevance.py
+++ b/ml-sidecars/indigenous-ml/tests/test_relevance.py
@@ -1,6 +1,8 @@
 """Tests for indigenous relevance classification (global multilingual)."""
 
 from classifier.relevance import (
+    CATEGORY_COUNT,
+    CATEGORY_KEYWORDS,
     CORE_INDIGENOUS,
     NOT_INDIGENOUS,
     PERIPHERAL_INDIGENOUS,
@@ -121,15 +123,27 @@ class TestJapanesePatterns:
 
 
 class TestCategories:
-    """Category extraction tests."""
+    """Category extraction tests for all 10 global categories."""
 
     def test_culture_category(self):
         result = classify_indigenous_relevance("First Nations powwow and ceremony celebrate culture")
         assert "culture" in result["categories"]
 
+    def test_language_category(self):
+        result = classify_indigenous_relevance("First Nations indigenous language revitalization program")
+        assert "language" in result["categories"]
+
     def test_land_rights_category(self):
         result = classify_indigenous_relevance("First Nations land rights and territory disputes")
         assert "land_rights" in result["categories"]
+
+    def test_environment_category(self):
+        result = classify_indigenous_relevance("First Nations water rights and climate change impact")
+        assert "environment" in result["categories"]
+
+    def test_sovereignty_category(self):
+        result = classify_indigenous_relevance("First Nations self-determination and sovereignty movement")
+        assert "sovereignty" in result["categories"]
 
     def test_education_category(self):
         result = classify_indigenous_relevance("Residential school survivors share stories of indigenous education")
@@ -138,6 +152,18 @@ class TestCategories:
     def test_health_category(self):
         result = classify_indigenous_relevance("Indigenous health crisis: traditional medicine programs expanded")
         assert "health" in result["categories"]
+
+    def test_justice_category(self):
+        result = classify_indigenous_relevance("First Nations missing and murdered inquiry continues")
+        assert "justice" in result["categories"]
+
+    def test_history_category(self):
+        result = classify_indigenous_relevance("First Nations colonial history and decolonization efforts")
+        assert "history" in result["categories"]
+
+    def test_community_category(self):
+        result = classify_indigenous_relevance("First Nations elders and youth gather for community event")
+        assert "community" in result["categories"]
 
     def test_max_categories(self):
         result = classify_indigenous_relevance(
@@ -153,3 +179,22 @@ class TestCategories:
     def test_whitespace_text(self):
         result = classify_indigenous_relevance("   ")
         assert result["relevance"] == NOT_INDIGENOUS
+
+
+class TestCategoryTaxonomy:
+    """Verify the category taxonomy structure."""
+
+    def test_category_count(self):
+        assert len(CATEGORY_KEYWORDS) == CATEGORY_COUNT
+
+    def test_all_slugs_present(self):
+        slugs = {cat for _, cat in CATEGORY_KEYWORDS}
+        expected = {
+            "culture", "language", "land_rights", "environment", "sovereignty",
+            "education", "health", "justice", "history", "community",
+        }
+        assert slugs == expected
+
+    def test_no_duplicate_slugs(self):
+        slugs = [cat for _, cat in CATEGORY_KEYWORDS]
+        assert len(slugs) == len(set(slugs))

--- a/publisher/internal/router/indigenous_test.go
+++ b/publisher/internal/router/indigenous_test.go
@@ -204,3 +204,60 @@ func TestGenerateIndigenousChannels_LatinAmericaHyphenated(t *testing.T) {
 		t.Errorf("expected indigenous:region:latin_america, got %v", channels)
 	}
 }
+
+func TestGenerateIndigenousChannels_AllNewCategories(t *testing.T) {
+	t.Helper()
+
+	// Verify all 10 global categories route to correct channel slugs.
+	categories := []string{
+		"culture", "language", "land_rights", "environment", "sovereignty",
+		"education", "health", "justice", "history", "community",
+	}
+
+	for _, cat := range categories {
+		t.Run(cat, func(t *testing.T) {
+			t.Helper()
+			item := &ContentItem{
+				Title: "Test article for " + cat,
+				Indigenous: &IndigenousData{
+					Relevance:  IndigenousRelevanceCore,
+					Categories: []string{cat},
+				},
+			}
+
+			routes := NewIndigenousDomain().Routes(item)
+			channels := routeChannelNames(routes)
+			expectedChannel := "indigenous:category:" + cat
+			found := false
+			for _, c := range channels {
+				if c == expectedChannel {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected %s channel, got %v", expectedChannel, channels)
+			}
+		})
+	}
+}
+
+func TestGenerateIndigenousChannels_MultipleNewCategories(t *testing.T) {
+	t.Helper()
+	item := &ContentItem{
+		Title: "Indigenous environmental justice",
+		Indigenous: &IndigenousData{
+			Relevance:  IndigenousRelevanceCore,
+			Categories: []string{"environment", "justice", "sovereignty"},
+		},
+	}
+
+	routes := NewIndigenousDomain().Routes(item)
+	channels := routeChannelNames(routes)
+
+	// Should have content:indigenous + 3 category channels = 4 total
+	expectedCount := 4
+	if len(channels) != expectedCount {
+		t.Errorf("expected %d channels, got %d: %v", expectedCount, len(channels), channels)
+	}
+}


### PR DESCRIPTION
## Summary

- Expands indigenous category taxonomy from 6 Canada-centric to 10 globally applicable categories
- ML Sidecar: structured `CATEGORY_KEYWORDS` with per-language placeholder comments, `CATEGORY_COUNT` constant
- Go Classifier: 10 category constants + `IndigenousCategories` slice for cross-referencing
- Publisher: tests verifying all 10 categories route correctly to `indigenous:category:{slug}` channels
- Design doc: `docs/plans/2026-03-11-indigenous-category-taxonomy.md`

Closes #211

## Test plan

- [x] Python: 37 tests (10 per-category, 3 taxonomy structure, 24 existing) — all pass
- [x] Go classifier: `TestIndigenousCategoryTaxonomy` + all existing indigenous rules tests — all pass
- [x] Publisher: `TestGenerateIndigenousChannels_AllNewCategories` (10 subtests) + `TestGenerateIndigenousChannels_MultipleNewCategories` — all pass
- [x] Classifier and publisher lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)