### PR TITLE
feat(crawler): integrate Playwright render worker into frontier fetcher

### DIFF
--- a/crawler/internal/bootstrap/fetcher_adapters.go
+++ b/crawler/internal/bootstrap/fetcher_adapters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/database"
 	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
 	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
+	"github.com/jonesrussell/north-cloud/crawler/internal/render"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/apiclient"
 	"github.com/jonesrussell/north-cloud/crawler/internal/storage"
 	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
@@ -132,6 +133,51 @@ func (a *contentIndexerAdapter) resolveSourceName(ctx context.Context, sourceID 
 
 	a.sourceCache.Store(sourceID, source.Name)
 	return source.Name, nil
+}
+
+// === renderClientAdapter ===
+
+// renderClientAdapter bridges fetcher.PageRenderer to render.Client.
+type renderClientAdapter struct {
+	client *render.Client
+}
+
+func (a *renderClientAdapter) Render(ctx context.Context, url string) (*fetcher.RenderedPage, error) {
+	resp, err := a.client.Render(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fetcher.RenderedPage{
+		HTML:       resp.HTML,
+		FinalURL:   resp.FinalURL,
+		StatusCode: resp.StatusCode,
+	}, nil
+}
+
+// === renderModeResolverAdapter ===
+
+// renderModeResolverAdapter bridges fetcher.SourceRenderModeResolver to the source-manager API.
+// Source configs are cached in memory to avoid an API call per page fetch.
+type renderModeResolverAdapter struct {
+	apiClient   *apiclient.Client
+	sourceCache sync.Map // map[string]string (sourceID → renderMode)
+}
+
+func (a *renderModeResolverAdapter) GetRenderMode(ctx context.Context, sourceID string) (string, error) {
+	if cached, ok := a.sourceCache.Load(sourceID); ok {
+		mode, _ := cached.(string)
+		return mode, nil
+	}
+
+	source, err := a.apiClient.GetSource(ctx, sourceID)
+	if err != nil {
+		return "", fmt.Errorf("get source %s for render mode: %w", sourceID, err)
+	}
+
+	a.sourceCache.Store(sourceID, source.RenderMode)
+
+	return source.RenderMode, nil
 }
 
 // mapExtractedToRawContent converts fetcher.ExtractedContent to storage.RawContent.

--- a/crawler/internal/bootstrap/services.go
+++ b/crawler/internal/bootstrap/services.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
 	"github.com/jonesrussell/north-cloud/crawler/internal/logs"
 	"github.com/jonesrussell/north-cloud/crawler/internal/proxypool"
+	"github.com/jonesrussell/north-cloud/crawler/internal/render"
 	"github.com/jonesrussell/north-cloud/crawler/internal/scheduler"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources"
 	"github.com/jonesrussell/north-cloud/crawler/internal/sources/apiclient"
@@ -646,6 +647,18 @@ func createFrontierWorkerPool(
 
 	wpLogger := &logAdapter{log: deps.Logger}
 
+	// Wire render worker if configured.
+	crawlerCfg := deps.Config.GetCrawlerConfig()
+	var renderer fetcher.PageRenderer
+	var modeResolver fetcher.SourceRenderModeResolver
+	if crawlerCfg.RenderWorkerURL != "" {
+		renderClient := render.NewClient(crawlerCfg.RenderWorkerURL)
+		renderer = &renderClientAdapter{client: renderClient}
+		modeResolver = &renderModeResolverAdapter{apiClient: apiClient}
+		deps.Logger.Info("Render worker enabled",
+			infralogger.String("render_worker_url", crawlerCfg.RenderWorkerURL))
+	}
+
 	cfg := fetcher.WorkerPoolConfig{
 		WorkerCount:     fetcherCfg.WorkerCount,
 		UserAgent:       fetcherCfg.UserAgent,
@@ -653,6 +666,8 @@ func createFrontierWorkerPool(
 		ClaimRetryDelay: fetcherCfg.ClaimRetryDelay,
 		RequestTimeout:  fetcherCfg.RequestTimeout,
 		HTTPClient:      httpClient,
+		Renderer:        renderer,
+		ModeResolver:    modeResolver,
 	}
 
 	deps.Logger.Info("Frontier worker pool created",

--- a/crawler/internal/fetcher/render_worker_test.go
+++ b/crawler/internal/fetcher/render_worker_test.go
@@ -1,0 +1,178 @@
+package fetcher_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/jonesrussell/north-cloud/crawler/internal/domain"
+	"github.com/jonesrussell/north-cloud/crawler/internal/fetcher"
+)
+
+// mockRenderer implements fetcher.PageRenderer for testing.
+type mockRenderer struct {
+	page      *fetcher.RenderedPage
+	err       error
+	callCount int
+}
+
+func (m *mockRenderer) Render(_ context.Context, _ string) (*fetcher.RenderedPage, error) {
+	m.callCount++
+	return m.page, m.err
+}
+
+// mockModeResolver implements fetcher.SourceRenderModeResolver for testing.
+type mockModeResolver struct {
+	mode string
+	err  error
+}
+
+func (m *mockModeResolver) GetRenderMode(_ context.Context, _ string) (string, error) {
+	return m.mode, m.err
+}
+
+// buildRenderPool creates a WorkerPool wired with a renderer and mode resolver.
+func buildRenderPool(
+	t *testing.T,
+	frontier fetcher.FrontierClaimer,
+	renderer fetcher.PageRenderer,
+	resolver fetcher.SourceRenderModeResolver,
+) *fetcher.WorkerPool {
+	t.Helper()
+
+	cfg := fetcher.WorkerPoolConfig{
+		WorkerCount:     workerTestWorkers,
+		UserAgent:       workerTestAgent,
+		MaxRetries:      workerTestRetries,
+		ClaimRetryDelay: workerClaimRetryDelay,
+		RequestTimeout:  workerRequestTimeout,
+		Renderer:        renderer,
+		ModeResolver:    resolver,
+	}
+
+	return fetcher.NewWorkerPool(
+		frontier,
+		&mockHostUpdater{},
+		&mockRobots{allowed: true},
+		fetcher.NewContentExtractor(),
+		&mockIndexer{},
+		&mockLogger{},
+		cfg,
+	)
+}
+
+// TestProcessURL_DynamicRender_UsesRenderer verifies that a dynamic source
+// routes through the Playwright render worker instead of plain HTTP.
+func TestProcessURL_DynamicRender_UsesRenderer(t *testing.T) {
+	t.Parallel()
+
+	frontier := &mockFrontier{
+		claimFunc: func(_ context.Context) (*domain.FrontierURL, error) {
+			return nil, fetcher.ErrNoURLAvailable
+		},
+	}
+
+	renderer := &mockRenderer{
+		page: &fetcher.RenderedPage{
+			HTML:       articleHTML,
+			FinalURL:   workerTestURL,
+			StatusCode: http.StatusOK,
+		},
+	}
+
+	resolver := &mockModeResolver{mode: "dynamic"}
+
+	pool := buildRenderPool(t, frontier, renderer, resolver)
+
+	furl := &domain.FrontierURL{
+		ID:       workerTestURLID,
+		URL:      workerTestURL,
+		Host:     workerTestHost,
+		SourceID: workerTestSourceID,
+	}
+
+	if err := pool.ProcessURL(context.Background(), furl); err != nil {
+		t.Fatalf("ProcessURL returned error: %v", err)
+	}
+
+	if renderer.callCount != 1 {
+		t.Errorf("expected renderer called once, got %d", renderer.callCount)
+	}
+}
+
+// TestProcessURL_StaticRender_UsesHTTP verifies that a static source
+// uses plain HTTP and does NOT invoke the render worker.
+func TestProcessURL_StaticRender_UsesHTTP(t *testing.T) {
+	t.Parallel()
+
+	server := startTestServer(t, http.StatusOK, articleHTML)
+
+	frontier := &mockFrontier{
+		claimFunc: func(_ context.Context) (*domain.FrontierURL, error) {
+			return nil, fetcher.ErrNoURLAvailable
+		},
+	}
+
+	renderer := &mockRenderer{
+		err: errors.New("renderer must not be called for static sources"),
+	}
+
+	resolver := &mockModeResolver{mode: "static"}
+
+	pool := buildRenderPool(t, frontier, renderer, resolver)
+
+	furl := &domain.FrontierURL{
+		ID:       workerTestURLID,
+		URL:      server.URL + "/article",
+		Host:     workerTestHost,
+		SourceID: workerTestSourceID,
+	}
+
+	if err := pool.ProcessURL(context.Background(), furl); err != nil {
+		t.Fatalf("ProcessURL returned error: %v", err)
+	}
+
+	if renderer.callCount != 0 {
+		t.Errorf("expected renderer NOT called for static source, got %d calls", renderer.callCount)
+	}
+}
+
+// TestProcessURL_RendererError_MarksURLFailed verifies that a render worker
+// failure causes the URL to be marked as failed in the frontier.
+func TestProcessURL_RendererError_MarksURLFailed(t *testing.T) {
+	t.Parallel()
+
+	frontier := &mockFrontier{
+		claimFunc: func(_ context.Context) (*domain.FrontierURL, error) {
+			return nil, fetcher.ErrNoURLAvailable
+		},
+	}
+
+	renderer := &mockRenderer{
+		err: errors.New("playwright timeout"),
+	}
+
+	resolver := &mockModeResolver{mode: "dynamic"}
+
+	pool := buildRenderPool(t, frontier, renderer, resolver)
+
+	furl := &domain.FrontierURL{
+		ID:       workerTestURLID,
+		URL:      workerTestURL,
+		Host:     workerTestHost,
+		SourceID: workerTestSourceID,
+	}
+
+	if err := pool.ProcessURL(context.Background(), furl); err != nil {
+		t.Fatalf("ProcessURL returned error: %v", err)
+	}
+
+	frontier.mu.Lock()
+	failedCount := len(frontier.failedCalls)
+	frontier.mu.Unlock()
+
+	if failedCount != 1 {
+		t.Fatalf("expected 1 failed call, got %d", failedCount)
+	}
+}

--- a/crawler/internal/fetcher/worker.go
+++ b/crawler/internal/fetcher/worker.go
@@ -34,6 +34,29 @@ const (
 	reasonExtractFailed          = "extract_failed"
 )
 
+// renderModeDynamic is the render mode value indicating Playwright rendering is required.
+const renderModeDynamic = "dynamic"
+
+// renderedPageContentType is the Content-Type returned for Playwright-rendered pages.
+const renderedPageContentType = "text/html; charset=utf-8"
+
+// RenderedPage holds the result of a dynamic Playwright render.
+type RenderedPage struct {
+	HTML       string
+	FinalURL   string
+	StatusCode int
+}
+
+// PageRenderer renders a URL using a headless browser and returns the HTML.
+type PageRenderer interface {
+	Render(ctx context.Context, url string) (*RenderedPage, error)
+}
+
+// SourceRenderModeResolver looks up the render mode ("static" or "dynamic") for a source.
+type SourceRenderModeResolver interface {
+	GetRenderMode(ctx context.Context, sourceID string) (string, error)
+}
+
 // binaryExtensions are file extensions that indicate binary/non-content resources.
 // These URLs are marked dead in the frontier to avoid repeated parse failures.
 var binaryExtensions = []string{
@@ -103,6 +126,10 @@ type WorkerPoolConfig struct {
 	RequestTimeout  time.Duration
 	// HTTPClient is the client used for fetches. If nil, a default client with RequestTimeout is used.
 	HTTPClient *http.Client
+	// Renderer renders pages via a headless browser. Nil disables dynamic rendering.
+	Renderer PageRenderer
+	// ModeResolver resolves the render mode for a source. Nil disables dynamic rendering.
+	ModeResolver SourceRenderModeResolver
 }
 
 // WorkerPool manages a pool of fetch workers that process URLs from the frontier.
@@ -114,6 +141,8 @@ type WorkerPool struct {
 	indexer         ContentIndexer
 	log             WorkerLogger
 	httpClient      *http.Client
+	renderer        PageRenderer
+	modeResolver    SourceRenderModeResolver
 	userAgent       string
 	workerCount     int
 	maxRetries      int
@@ -142,6 +171,8 @@ func NewWorkerPool(
 		indexer:         indexer,
 		log:             log,
 		httpClient:      client,
+		renderer:        cfg.Renderer,
+		modeResolver:    cfg.ModeResolver,
 		userAgent:       cfg.UserAgent,
 		workerCount:     cfg.WorkerCount,
 		maxRetries:      cfg.MaxRetries,
@@ -237,7 +268,7 @@ func (wp *WorkerPool) ProcessURL(ctx context.Context, furl *domain.FrontierURL) 
 		return nil
 	}
 
-	body, statusCode, finalURL, contentType, fetchErr := wp.fetchPage(ctx, furl)
+	body, statusCode, finalURL, contentType, fetchErr := wp.fetchWithRenderMode(ctx, furl)
 
 	// Always update host last fetch time after any fetch attempt.
 	wp.updateHostFetch(ctx, furl.Host)
@@ -403,6 +434,31 @@ func (wp *WorkerPool) updateFetchedWithOptionalFinalURL(
 		return wp.frontier.UpdateFetched(ctx, furl.ID, params)
 	}
 	return wp.frontier.UpdateFetchedWithFinalURL(ctx, furl.ID, finalURL, params)
+}
+
+// fetchWithRenderMode fetches a page using the render worker for dynamic sources,
+// or plain HTTP for static sources (or when rendering is not configured).
+func (wp *WorkerPool) fetchWithRenderMode(
+	ctx context.Context,
+	furl *domain.FrontierURL,
+) (body []byte, statusCode int, finalURL, contentType string, err error) {
+	if wp.renderer != nil && wp.modeResolver != nil {
+		mode, resolveErr := wp.modeResolver.GetRenderMode(ctx, furl.SourceID)
+		if resolveErr != nil {
+			return nil, 0, "", "", fmt.Errorf("resolve render mode: %w", resolveErr)
+		}
+
+		if mode == renderModeDynamic {
+			page, renderErr := wp.renderer.Render(ctx, furl.URL)
+			if renderErr != nil {
+				return nil, 0, "", "", fmt.Errorf("render: %w", renderErr)
+			}
+
+			return []byte(page.HTML), page.StatusCode, page.FinalURL, renderedPageContentType, nil
+		}
+	}
+
+	return wp.fetchPage(ctx, furl)
 }
 
 // fetchPage performs the HTTP GET request for the given frontier URL.


### PR DESCRIPTION
## Summary

- Wire the `render-worker` (Playwright sidecar) into the frontier URL fetcher so sources with `render_mode=dynamic` use headless-browser rendering instead of plain HTTP GETs
- Add `PageRenderer` / `SourceRenderModeResolver` interfaces + `RenderedPage` type to the `fetcher` package for testability and clear separation of concerns
- Add `renderClientAdapter` and `renderModeResolverAdapter` (with `sync.Map` source-config cache) to `bootstrap/fetcher_adapters.go`
- Wire adapters in `createFrontierWorkerPool` when `CRAWLER_RENDER_WORKER_URL` is set; gracefully no-ops for static sources
- Three TDD tests: dynamic route uses renderer, static route uses HTTP, render errors mark URL as failed

## Background

The `render-worker` Node.js/Playwright sidecar has existed in the codebase for a while but was never called — the frontier fetcher always used plain HTTP regardless of the source's `render_mode` field. This PR closes that integration gap.

Related production work done prior to this PR:
- `CRAWLER_RENDER_WORKER_URL` added to `docker-compose.prod.yml` crawler env and `depends_on`
- Render-worker structured JSON logging (startup, render start/complete/error, 5-min heartbeat) deployed to production
- Grafana alerts added: render-worker down (no heartbeat in 10m) + sustained error rate (>5 errors in 15m)
- Grafana ML Sidecars dashboard extended with render-worker panels (renders/5m, errors/5m, heartbeat status, log stream)
- 5 procurement sources updated to `render_mode=dynamic` in source-manager DB: `ontariotenders`, `biddingo`, `merx`, `bcbid`, `canadabuys`

## How it works

```
FrontierURL.SourceID
      │
      ▼
renderModeResolverAdapter.GetRenderMode()  ← cached API call to source-manager
      │
      ├─ "static" (or resolver nil) → fetchPage()  (existing plain HTTP)
      │
      └─ "dynamic" → renderClientAdapter.Render()  → POST render-worker:3000/render
                                                       (Playwright headless Chrome)
```

## Test plan

- [x] `GOWORK=off go test ./internal/fetcher/...` — all 3 new render tests pass
- [x] `GOWORK=off go test ./...` — full crawler test suite passes
- [x] `GOWORK=off golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)