### PR TITLE
feat(drift): add drift category, bootstrap wiring, and dual-ticker scheduler

### DIFF
--- a/ai-observer/internal/bootstrap/app.go
+++ b/ai-observer/internal/bootstrap/app.go
@@ -12,10 +12,17 @@ import (
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/category"
 	classifiercategory "github.com/jonesrussell/north-cloud/ai-observer/internal/category/classifier"
+	driftcategory "github.com/jonesrussell/north-cloud/ai-observer/internal/category/drift"
+	driftpkg "github.com/jonesrussell/north-cloud/ai-observer/internal/drift"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/insights"
 	anthprovider "github.com/jonesrussell/north-cloud/ai-observer/internal/provider/anthropic"
 	"github.com/jonesrussell/north-cloud/ai-observer/internal/scheduler"
 	"github.com/jonesrussell/north-cloud/infrastructure/logger"
+)
+
+const (
+	// driftWindowHours is the default window duration for drift category sampling.
+	driftWindowHours = 6
 )
 
 // Start initializes and runs the ai-observer service.
@@ -57,20 +64,31 @@ func Start() error {
 	}
 	log.Info("ai_insights index mapping ready")
 
+	if err = driftpkg.EnsureBaselineMapping(ctx, esClient); err != nil {
+		return fmt.Errorf("drift_baselines mapping: %w", err)
+	}
+	log.Info("drift_baselines index mapping ready")
+
 	p := anthprovider.New(cfg.Anthropic.APIKey, cfg.Anthropic.DefaultModel)
 	writer := insights.NewWriter(esClient, cfg.Service.Version)
-	cats := buildCategories(cfg, esClient)
+	fast, slow := buildCategories(cfg, esClient)
 
-	sched := scheduler.New(cats, writer, p, scheduler.Config{
+	sched := scheduler.New(fast, slow, writer, p, scheduler.Config{
 		IntervalSeconds:      cfg.Observer.IntervalSeconds,
 		MaxTokensPerInterval: cfg.Observer.MaxTokensPerInterval,
 		WindowDuration:       time.Hour,
 		DryRun:               cfg.Observer.DryRun,
+		DriftIntervalSeconds: cfg.Observer.Categories.DriftIntervalSeconds,
+		DriftWindowDuration:  driftWindowHours * time.Hour,
 	}).WithLogger(log)
 
+	totalCats := len(fast) + len(slow)
 	log.Info("Scheduler configured",
-		logger.Int("categories", len(cats)),
+		logger.Int("fast_categories", len(fast)),
+		logger.Int("slow_categories", len(slow)),
+		logger.Int("total_categories", totalCats),
 		logger.Int("interval_seconds", cfg.Observer.IntervalSeconds),
+		logger.Int("drift_interval_seconds", cfg.Observer.Categories.DriftIntervalSeconds),
 	)
 
 	go sched.Run(ctx)
@@ -83,16 +101,23 @@ func Start() error {
 	return nil
 }
 
-// buildCategories constructs the enabled category list from config.
-func buildCategories(cfg Config, esClient *es.Client) []category.Category {
-	const maxCategories = 1 // v0: classifier only
-	cats := make([]category.Category, 0, maxCategories)
+// buildCategories constructs the enabled category lists from config.
+// Returns fast (classifier) and slow (drift) category slices.
+func buildCategories(cfg Config, esClient *es.Client) (fast, slow []category.Category) {
 	if cfg.Observer.Categories.ClassifierEnabled {
-		cats = append(cats, classifiercategory.New(
+		fast = append(fast, classifiercategory.New(
 			esClient,
 			cfg.Observer.Categories.ClassifierMaxEvents,
 			cfg.Observer.Categories.ClassifierModel,
 		))
 	}
-	return cats
+	if cfg.Observer.Categories.DriftEnabled {
+		slow = append(slow, driftcategory.New(esClient, driftcategory.Config{
+			KLThreshold:        cfg.Observer.Categories.DriftKLThreshold,
+			PSIThreshold:       cfg.Observer.Categories.DriftPSIThreshold,
+			MatrixThreshold:    cfg.Observer.Categories.DriftMatrixThreshold,
+			BaselineWindowDays: cfg.Observer.Categories.DriftBaselineWindowDays,
+		}))
+	}
+	return fast, slow
 }

--- a/ai-observer/internal/bootstrap/config.go
+++ b/ai-observer/internal/bootstrap/config.go
@@ -39,9 +39,16 @@ type ObserverConfig struct {
 
 // CategoriesConfig holds per-category feature flags.
 type CategoriesConfig struct {
-	ClassifierEnabled   bool
-	ClassifierMaxEvents int
-	ClassifierModel     string
+	ClassifierEnabled       bool
+	ClassifierMaxEvents     int
+	ClassifierModel         string
+	DriftEnabled            bool
+	DriftIntervalSeconds    int
+	DriftKLThreshold        float64
+	DriftPSIThreshold       float64
+	DriftMatrixThreshold    float64
+	DriftBaselineWindowDays int
+	DriftBaselineRetention  int
 }
 
 // AnthropicConfig holds Anthropic API config.
@@ -51,12 +58,19 @@ type AnthropicConfig struct {
 }
 
 const (
-	defaultIntervalSeconds      = 1800
-	defaultMaxTokensPerInterval = 25000
-	defaultClassifierMaxEvents  = 200
-	defaultClassifierModel      = "claude-haiku-4-5-20251001"
-	serviceName                 = "ai-observer"
-	serviceVersion              = "0.1.0"
+	defaultIntervalSeconds         = 1800
+	defaultMaxTokensPerInterval    = 25000
+	defaultClassifierMaxEvents     = 200
+	defaultClassifierModel         = "claude-haiku-4-5-20251001"
+	defaultDriftIntervalSeconds    = 21600
+	defaultDriftKLThreshold        = 0.15
+	defaultDriftPSIThreshold       = 0.25
+	defaultDriftMatrixThreshold    = 0.20
+	defaultDriftBaselineWindowDays = 7
+	defaultDriftBaselineRetention  = 30
+	float64BitSize                 = 64
+	serviceName                    = "ai-observer"
+	serviceVersion                 = "0.1.0"
 )
 
 // LoadConfig loads configuration from environment variables.
@@ -84,6 +98,11 @@ func LoadConfig() (Config, error) {
 		return Config{}, err
 	}
 
+	driftCfg, err := loadDriftConfig()
+	if err != nil {
+		return Config{}, err
+	}
+
 	return Config{
 		Service: ServiceConfig{
 			Name:    serviceName,
@@ -100,9 +119,16 @@ func LoadConfig() (Config, error) {
 			IntervalSeconds:      intervalSeconds,
 			MaxTokensPerInterval: maxTokens,
 			Categories: CategoriesConfig{
-				ClassifierEnabled:   os.Getenv("AI_OBSERVER_CATEGORY_CLASSIFIER_ENABLED") != "false",
-				ClassifierMaxEvents: defaultClassifierMaxEvents,
-				ClassifierModel:     defaultClassifierModel,
+				ClassifierEnabled:       os.Getenv("AI_OBSERVER_CATEGORY_CLASSIFIER_ENABLED") != "false",
+				ClassifierMaxEvents:     defaultClassifierMaxEvents,
+				ClassifierModel:         defaultClassifierModel,
+				DriftEnabled:            driftCfg.DriftEnabled,
+				DriftIntervalSeconds:    driftCfg.DriftIntervalSeconds,
+				DriftKLThreshold:        driftCfg.DriftKLThreshold,
+				DriftPSIThreshold:       driftCfg.DriftPSIThreshold,
+				DriftMatrixThreshold:    driftCfg.DriftMatrixThreshold,
+				DriftBaselineWindowDays: driftCfg.DriftBaselineWindowDays,
+				DriftBaselineRetention:  driftCfg.DriftBaselineRetention,
 			},
 		},
 		Anthropic: AnthropicConfig{
@@ -110,6 +136,60 @@ func LoadConfig() (Config, error) {
 			DefaultModel: defaultClassifierModel,
 		},
 	}, nil
+}
+
+func loadDriftConfig() (CategoriesConfig, error) {
+	driftInterval, err := envInt("AI_OBSERVER_DRIFT_INTERVAL_SECONDS", defaultDriftIntervalSeconds)
+	if err != nil {
+		return CategoriesConfig{}, err
+	}
+
+	klThreshold, err := envFloat("AI_OBSERVER_DRIFT_KL_THRESHOLD", defaultDriftKLThreshold)
+	if err != nil {
+		return CategoriesConfig{}, err
+	}
+
+	psiThreshold, err := envFloat("AI_OBSERVER_DRIFT_PSI_THRESHOLD", defaultDriftPSIThreshold)
+	if err != nil {
+		return CategoriesConfig{}, err
+	}
+
+	matrixThreshold, err := envFloat("AI_OBSERVER_DRIFT_MATRIX_THRESHOLD", defaultDriftMatrixThreshold)
+	if err != nil {
+		return CategoriesConfig{}, err
+	}
+
+	baselineDays, err := envInt("AI_OBSERVER_DRIFT_BASELINE_WINDOW_DAYS", defaultDriftBaselineWindowDays)
+	if err != nil {
+		return CategoriesConfig{}, err
+	}
+
+	baselineRetention, err := envInt("AI_OBSERVER_DRIFT_BASELINE_RETENTION", defaultDriftBaselineRetention)
+	if err != nil {
+		return CategoriesConfig{}, err
+	}
+
+	return CategoriesConfig{
+		DriftEnabled:            os.Getenv("AI_OBSERVER_CATEGORY_DRIFT_ENABLED") == "true",
+		DriftIntervalSeconds:    driftInterval,
+		DriftKLThreshold:        klThreshold,
+		DriftPSIThreshold:       psiThreshold,
+		DriftMatrixThreshold:    matrixThreshold,
+		DriftBaselineWindowDays: baselineDays,
+		DriftBaselineRetention:  baselineRetention,
+	}, nil
+}
+
+func envFloat(key string, def float64) (float64, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.ParseFloat(v, float64BitSize)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", key, err)
+	}
+	return n, nil
 }
 
 func envInt(key string, def int) (int, error) {

--- a/ai-observer/internal/bootstrap/config_test.go
+++ b/ai-observer/internal/bootstrap/config_test.go
@@ -50,3 +50,34 @@ func TestLoadConfig_DisabledNoAPIKey(t *testing.T) {
 		t.Errorf("expected no error when observer is disabled without API key, got: %v", err)
 	}
 }
+
+func TestLoadConfig_DriftDefaults(t *testing.T) {
+	t.Helper()
+	t.Setenv("AI_OBSERVER_ENABLED", "false")
+
+	cfg, err := bootstrap.LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Observer.Categories.DriftEnabled {
+		t.Error("expected drift disabled by default")
+	}
+
+	const expectedKLThreshold = 0.15
+	if cfg.Observer.Categories.DriftKLThreshold != expectedKLThreshold {
+		t.Errorf("expected KL threshold %f, got %f",
+			expectedKLThreshold, cfg.Observer.Categories.DriftKLThreshold)
+	}
+
+	const expectedPSIThreshold = 0.25
+	if cfg.Observer.Categories.DriftPSIThreshold != expectedPSIThreshold {
+		t.Errorf("expected PSI threshold %f, got %f",
+			expectedPSIThreshold, cfg.Observer.Categories.DriftPSIThreshold)
+	}
+
+	const expectedMatrixThreshold = 0.20
+	if cfg.Observer.Categories.DriftMatrixThreshold != expectedMatrixThreshold {
+		t.Errorf("expected matrix threshold %f, got %f",
+			expectedMatrixThreshold, cfg.Observer.Categories.DriftMatrixThreshold)
+	}
+}

--- a/ai-observer/internal/category/drift/analyzer.go
+++ b/ai-observer/internal/category/drift/analyzer.go
@@ -1,0 +1,130 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jonesrussell/north-cloud/ai-observer/internal/category"
+	driftpkg "github.com/jonesrussell/north-cloud/ai-observer/internal/drift"
+	"github.com/jonesrussell/north-cloud/ai-observer/internal/provider"
+)
+
+const (
+	driftAnalysisModel = "claude-haiku-4-5-20251001"
+	// maxResponseTokens is the LLM response token limit for drift analysis.
+	maxResponseTokens = 1500
+)
+
+const driftSystemPrompt = `You are an AI system observer analyzing statistical drift in a news content classifier.
+You receive drift metrics (KL divergence, PSI, cross-matrix deviations) that have breached thresholds.
+Your job is to:
+1. Explain the likely cause of the drift in plain language
+2. Suggest specific keyword rule changes (additions or removals) to address the drift
+3. Rate your confidence in each suggestion (high/medium/low)
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "summary": "one sentence explanation",
+  "suggested_actions": ["action 1", "action 2"],
+  "suggested_rules": [
+    {"operation": "add|remove", "topic": "topic_name", "keyword": "keyword", "confidence": "high|medium|low"}
+  ]
+}`
+
+// promptSignal is a JSON-tagged projection of DriftSignal for LLM prompts.
+type promptSignal struct {
+	Metric    string  `json:"metric"`
+	Scope     string  `json:"scope"`
+	Value     float64 `json:"value"`
+	Threshold float64 `json:"threshold"`
+}
+
+func toPromptSignals(signals []driftpkg.DriftSignal) []promptSignal {
+	out := make([]promptSignal, 0, len(signals))
+	for _, s := range signals {
+		if s.Breached {
+			out = append(out, promptSignal{
+				Metric:    s.Metric,
+				Scope:     s.Scope,
+				Value:     s.Value,
+				Threshold: s.Threshold,
+			})
+		}
+	}
+	return out
+}
+
+func analyzeDrift(
+	ctx context.Context,
+	p provider.LLMProvider,
+	signals []driftpkg.DriftSignal,
+) (*category.Insight, error) {
+	breachedSignals := toPromptSignals(signals)
+
+	promptData, err := json.Marshal(breachedSignals)
+	if err != nil {
+		return nil, fmt.Errorf("marshal signals for prompt: %w", err)
+	}
+
+	userPrompt := fmt.Sprintf(
+		"The following drift metrics have breached their thresholds:\n\n%s\n\nAnalyze the drift and suggest rule changes.",
+		string(promptData),
+	)
+
+	resp, err := p.Generate(ctx, provider.GenerateRequest{
+		SystemPrompt: driftSystemPrompt,
+		UserPrompt:   userPrompt,
+		MaxTokens:    maxResponseTokens,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("llm generate: %w", err)
+	}
+
+	return parseDriftResponse(resp)
+}
+
+type driftLLMResponse struct {
+	Summary          string   `json:"summary"`
+	SuggestedActions []string `json:"suggested_actions"`
+	SuggestedRules   []any    `json:"suggested_rules"`
+}
+
+func parseDriftResponse(resp provider.GenerateResponse) (*category.Insight, error) {
+	content := stripFences(resp.Content)
+
+	var parsed driftLLMResponse
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return nil, fmt.Errorf("parse drift LLM response: %w", err)
+	}
+
+	details := map[string]any{}
+	if len(parsed.SuggestedRules) > 0 {
+		details["suggested_rules"] = parsed.SuggestedRules
+		details["action_type"] = "rule_patch"
+	}
+
+	totalTokens := resp.InputTokens + resp.OutputTokens
+
+	return &category.Insight{
+		Category:         categoryName,
+		Summary:          parsed.Summary,
+		Details:          details,
+		SuggestedActions: parsed.SuggestedActions,
+		TokensUsed:       totalTokens,
+		Model:            driftAnalysisModel,
+	}, nil
+}
+
+// stripFences removes markdown code fences from LLM output.
+func stripFences(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "```json") {
+		s = strings.TrimPrefix(s, "```json")
+	} else if strings.HasPrefix(s, "```") {
+		s = strings.TrimPrefix(s, "```")
+	}
+	s = strings.TrimSuffix(s, "```")
+	return strings.TrimSpace(s)
+}

--- a/ai-observer/internal/category/drift/category.go
+++ b/ai-observer/internal/category/drift/category.go
@@ -1,0 +1,225 @@
+// Package drift implements the drift detection category for the AI observer.
+package drift
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	es "github.com/elastic/go-elasticsearch/v8"
+	"github.com/jonesrussell/north-cloud/ai-observer/internal/category"
+	driftpkg "github.com/jonesrussell/north-cloud/ai-observer/internal/drift"
+	"github.com/jonesrussell/north-cloud/ai-observer/internal/provider"
+)
+
+const (
+	categoryName    = "drift"
+	modelTier       = "haiku"
+	maxEventsPerRun = 0 // drift doesn't use event-based sampling
+)
+
+// Config holds drift category configuration.
+type Config struct {
+	KLThreshold        float64
+	PSIThreshold       float64
+	MatrixThreshold    float64
+	BaselineWindowDays int
+}
+
+// Category implements the category.Category interface for drift detection.
+type Category struct {
+	collector    *driftpkg.Collector
+	store        *driftpkg.Store
+	thresholds   driftpkg.Thresholds
+	baselineDays int
+}
+
+// New creates a new drift category.
+func New(esClient *es.Client, cfg Config) *Category {
+	return &Category{
+		collector: driftpkg.NewCollector(esClient),
+		store:     driftpkg.NewStore(esClient),
+		thresholds: driftpkg.Thresholds{
+			KLDivergence:    cfg.KLThreshold,
+			PSI:             cfg.PSIThreshold,
+			MatrixDeviation: cfg.MatrixThreshold,
+		},
+		baselineDays: cfg.BaselineWindowDays,
+	}
+}
+
+// Name returns the category name.
+func (c *Category) Name() string { return categoryName }
+
+// MaxEventsPerRun returns zero; drift uses distribution sampling, not event sampling.
+func (c *Category) MaxEventsPerRun() int { return maxEventsPerRun }
+
+// ModelTier returns the LLM tier used for drift analysis.
+func (c *Category) ModelTier() string { return modelTier }
+
+// Sample collects the current window distribution. Returns a synthetic event carrying
+// drift signals in Metadata -- the drift category doesn't use traditional event sampling.
+func (c *Category) Sample(ctx context.Context, window time.Duration) ([]category.Event, error) {
+	current, err := c.collector.CollectCurrentWindow(ctx, window)
+	if err != nil {
+		return nil, fmt.Errorf("collect current window: %w", err)
+	}
+	if current == nil {
+		return nil, nil
+	}
+
+	baseline, baselineErr := c.store.LoadLatestBaseline(ctx)
+	if baselineErr != nil {
+		if !errors.Is(baselineErr, driftpkg.ErrNoBaseline) {
+			return nil, fmt.Errorf("load baseline: %w", baselineErr)
+		}
+		// No baseline yet -- compute and store one, skip evaluation.
+		return c.initBaseline(ctx)
+	}
+
+	signals := driftpkg.Evaluate(baseline, current, c.thresholds)
+
+	return []category.Event{
+		{
+			Source:    "drift_evaluator",
+			Label:     "drift_signals",
+			Timestamp: time.Now().UTC(),
+			Metadata: map[string]any{
+				"signals":  signals,
+				"baseline": baseline,
+				"current":  current,
+			},
+		},
+	}, nil
+}
+
+func (c *Category) initBaseline(ctx context.Context) ([]category.Event, error) {
+	newBaseline, baselineErr := c.collector.CollectBaselineWindow(ctx, c.baselineDays)
+	if baselineErr != nil {
+		return nil, fmt.Errorf("compute initial baseline: %w", baselineErr)
+	}
+	if newBaseline != nil {
+		if storeErr := c.store.StoreBaseline(ctx, newBaseline); storeErr != nil {
+			return nil, fmt.Errorf("store initial baseline: %w", storeErr)
+		}
+	}
+	return nil, nil
+}
+
+// Analyze processes drift signals. If thresholds are breached, invokes the LLM
+// for contextual explanation. Always returns at least one insight with metric values.
+func (c *Category) Analyze(
+	ctx context.Context,
+	events []category.Event,
+	p provider.LLMProvider,
+) ([]category.Insight, error) {
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	signals, ok := events[0].Metadata["signals"].([]driftpkg.DriftSignal)
+	if !ok {
+		return nil, errors.New("unexpected signals type in metadata")
+	}
+
+	severity := driftpkg.SeverityFromSignals(signals)
+
+	insight := category.Insight{
+		Category: categoryName,
+		Severity: severity,
+		Summary:  buildSummary(signals),
+		Details:  buildDetails(signals),
+	}
+
+	if severity == "low" {
+		return []category.Insight{insight}, nil
+	}
+
+	// Breached -- invoke LLM for contextual analysis.
+	if p != nil {
+		return []category.Insight{enrichWithLLM(ctx, p, signals, insight)}, nil
+	}
+
+	return []category.Insight{insight}, nil
+}
+
+func enrichWithLLM(
+	ctx context.Context,
+	p provider.LLMProvider,
+	signals []driftpkg.DriftSignal,
+	insight category.Insight,
+) category.Insight {
+	llmInsight, llmErr := analyzeDrift(ctx, p, signals)
+	if llmErr != nil {
+		insight.SuggestedActions = []string{"LLM analysis failed: " + llmErr.Error()}
+		return insight
+	}
+	insight.SuggestedActions = llmInsight.SuggestedActions
+	insight.TokensUsed = llmInsight.TokensUsed
+	insight.Model = llmInsight.Model
+	if llmInsight.Summary != "" {
+		insight.Summary = llmInsight.Summary
+	}
+	for k, v := range llmInsight.Details {
+		insight.Details[k] = v
+	}
+	return insight
+}
+
+func buildSummary(signals []driftpkg.DriftSignal) string {
+	var breached int
+	var first driftpkg.DriftSignal
+	for _, s := range signals {
+		if s.Breached {
+			breached++
+			if breached == 1 {
+				first = s
+			}
+		}
+	}
+
+	if breached == 0 {
+		return "No drift detected -- all metrics within thresholds"
+	}
+	if breached == 1 {
+		return fmt.Sprintf("%s %.3f (threshold %.2f) in %s",
+			first.Metric, first.Value, first.Threshold, first.Scope)
+	}
+	return fmt.Sprintf("%d metrics breached -- %s %.3f in %s (and %d more)",
+		breached, first.Metric, first.Value, first.Scope, breached-1)
+}
+
+func buildDetails(signals []driftpkg.DriftSignal) map[string]any {
+	details := map[string]any{
+		"signal_count": len(signals),
+		"breach_count": countBreaches(signals),
+	}
+
+	breachedSignals := make([]map[string]any, 0)
+	for _, s := range signals {
+		if s.Breached {
+			breachedSignals = append(breachedSignals, map[string]any{
+				"metric":    s.Metric,
+				"scope":     s.Scope,
+				"value":     s.Value,
+				"threshold": s.Threshold,
+			})
+		}
+	}
+	if len(breachedSignals) > 0 {
+		details["breached_signals"] = breachedSignals
+	}
+
+	return details
+}
+
+func countBreaches(signals []driftpkg.DriftSignal) int {
+	var count int
+	for _, s := range signals {
+		if s.Breached {
+			count++
+		}
+	}
+	return count
+}

--- a/ai-observer/internal/category/drift/category_test.go
+++ b/ai-observer/internal/category/drift/category_test.go
@@ -1,0 +1,37 @@
+package drift_test
+
+import (
+	"testing"
+
+	"github.com/jonesrussell/north-cloud/ai-observer/internal/category"
+	driftcat "github.com/jonesrussell/north-cloud/ai-observer/internal/category/drift"
+)
+
+func TestDriftCategory_ImplementsInterface(t *testing.T) {
+	t.Helper()
+	var _ category.Category = (*driftcat.Category)(nil)
+}
+
+func TestDriftCategory_Name(t *testing.T) {
+	t.Helper()
+	c := driftcat.New(nil, driftcat.Config{})
+	if got := c.Name(); got != "drift" {
+		t.Errorf("expected name 'drift', got %q", got)
+	}
+}
+
+func TestDriftCategory_MaxEventsPerRun(t *testing.T) {
+	t.Helper()
+	c := driftcat.New(nil, driftcat.Config{})
+	if got := c.MaxEventsPerRun(); got != 0 {
+		t.Errorf("expected MaxEventsPerRun 0, got %d", got)
+	}
+}
+
+func TestDriftCategory_ModelTier(t *testing.T) {
+	t.Helper()
+	c := driftcat.New(nil, driftcat.Config{})
+	if got := c.ModelTier(); got != "haiku" {
+		t.Errorf("expected model tier 'haiku', got %q", got)
+	}
+}

--- a/ai-observer/internal/scheduler/scheduler.go
+++ b/ai-observer/internal/scheduler/scheduler.go
@@ -25,6 +25,8 @@ type Config struct {
 	MaxTokensPerInterval int
 	WindowDuration       time.Duration
 	DryRun               bool
+	DriftIntervalSeconds int
+	DriftWindowDuration  time.Duration
 }
 
 // Budget is a thread-safe token budget for a single polling interval.
@@ -70,25 +72,28 @@ type categoryResult struct {
 
 // Scheduler runs category passes on a ticker and emits insights.
 type Scheduler struct {
-	categories []category.Category
-	writer     *insights.Writer
-	provider   provider.LLMProvider
-	cfg        Config
-	log        logger.Logger
+	fastCategories []category.Category
+	slowCategories []category.Category
+	writer         *insights.Writer
+	provider       provider.LLMProvider
+	cfg            Config
+	log            logger.Logger
 }
 
-// New creates a new Scheduler.
+// New creates a new Scheduler with fast (frequent) and slow (drift) category slices.
 func New(
-	categories []category.Category,
+	fastCategories []category.Category,
+	slowCategories []category.Category,
 	writer *insights.Writer,
 	p provider.LLMProvider,
 	cfg Config,
 ) *Scheduler {
 	return &Scheduler{
-		categories: categories,
-		writer:     writer,
-		provider:   p,
-		cfg:        cfg,
+		fastCategories: fastCategories,
+		slowCategories: slowCategories,
+		writer:         writer,
+		provider:       p,
+		cfg:            cfg,
 	}
 }
 
@@ -99,41 +104,90 @@ func (s *Scheduler) WithLogger(log logger.Logger) *Scheduler {
 }
 
 // Run starts the polling loop and blocks until ctx is cancelled.
+// Uses dual tickers: fast for classifier categories, slow for drift categories.
 func (s *Scheduler) Run(ctx context.Context) {
-	interval := time.Duration(s.cfg.IntervalSeconds) * time.Second
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	fastInterval := time.Duration(s.cfg.IntervalSeconds) * time.Second
+	fastTicker := time.NewTicker(fastInterval)
+	defer fastTicker.Stop()
 
-	s.logInfo("Scheduler started", logger.Int("interval_seconds", s.cfg.IntervalSeconds))
-	s.RunOnce(ctx) // run immediately on start
+	s.logInfo("Scheduler started",
+		logger.Int("fast_interval_seconds", s.cfg.IntervalSeconds),
+		logger.Int("slow_interval_seconds", s.cfg.DriftIntervalSeconds),
+	)
+	s.RunOnce(ctx)
 
+	if s.cfg.DriftIntervalSeconds <= 0 || len(s.slowCategories) == 0 {
+		s.runFastOnly(ctx, fastTicker)
+		return
+	}
+
+	slowInterval := time.Duration(s.cfg.DriftIntervalSeconds) * time.Second
+	slowTicker := time.NewTicker(slowInterval)
+	defer slowTicker.Stop()
+
+	s.RunDrift(ctx)
+	s.runDualTicker(ctx, fastTicker, slowTicker)
+}
+
+func (s *Scheduler) runFastOnly(ctx context.Context, fastTicker *time.Ticker) {
 	for {
 		select {
 		case <-ctx.Done():
 			s.logInfo("Scheduler stopping")
 			return
-		case <-ticker.C:
+		case <-fastTicker.C:
 			s.RunOnce(ctx)
 		}
 	}
 }
 
-// RunOnce executes one polling cycle: sample all categories in parallel, collect insights, write.
+func (s *Scheduler) runDualTicker(
+	ctx context.Context,
+	fastTicker *time.Ticker,
+	slowTicker *time.Ticker,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			s.logInfo("Scheduler stopping")
+			return
+		case <-fastTicker.C:
+			s.RunOnce(ctx)
+		case <-slowTicker.C:
+			s.RunDrift(ctx)
+		}
+	}
+}
+
+// RunOnce executes one polling cycle for fast categories.
 func (s *Scheduler) RunOnce(ctx context.Context) {
-	if len(s.categories) == 0 {
+	s.runCategories(ctx, s.fastCategories, s.cfg.WindowDuration)
+}
+
+// RunDrift executes one polling cycle for slow (drift) categories.
+func (s *Scheduler) RunDrift(ctx context.Context) {
+	s.runCategories(ctx, s.slowCategories, s.cfg.DriftWindowDuration)
+}
+
+func (s *Scheduler) runCategories(
+	ctx context.Context,
+	cats []category.Category,
+	window time.Duration,
+) {
+	if len(cats) == 0 {
 		return
 	}
 
 	budget := NewBudget(s.cfg.MaxTokensPerInterval)
-	results := make(chan categoryResult, len(s.categories))
+	results := make(chan categoryResult, len(cats))
 
 	var wg sync.WaitGroup
-	for _, cat := range s.categories {
+	for _, cat := range cats {
 		wg.Add(1)
 		go func(c category.Category) {
 			defer wg.Done()
-			ins, err := s.runCategory(ctx, c, budget)
-			results <- categoryResult{insights: ins, err: err}
+			ins, runErr := s.runCategory(ctx, c, budget, window)
+			results <- categoryResult{insights: ins, err: runErr}
 		}(cat)
 	}
 
@@ -145,7 +199,7 @@ func (s *Scheduler) RunOnce(ctx context.Context) {
 }
 
 func (s *Scheduler) collectInsights(results <-chan categoryResult) []category.Insight {
-	allInsights := make([]category.Insight, 0, len(s.categories))
+	allInsights := make([]category.Insight, 0)
 	for r := range results {
 		if r.err != nil {
 			s.logError("category error", r.err)
@@ -171,7 +225,12 @@ func (s *Scheduler) writeInsights(ctx context.Context, allInsights []category.In
 	}
 }
 
-func (s *Scheduler) runCategory(ctx context.Context, cat category.Category, budget *Budget) ([]category.Insight, error) {
+func (s *Scheduler) runCategory(
+	ctx context.Context,
+	cat category.Category,
+	budget *Budget,
+	window time.Duration,
+) ([]category.Insight, error) {
 	if s.cfg.DryRun {
 		s.logInfo("Dry run: skipping LLM call", logger.String("category", cat.Name()))
 		return nil, nil
@@ -180,7 +239,7 @@ func (s *Scheduler) runCategory(ctx context.Context, cat category.Category, budg
 	catCtx, cancel := context.WithTimeout(ctx, categoryTimeout)
 	defer cancel()
 
-	events, err := cat.Sample(catCtx, s.cfg.WindowDuration)
+	events, err := cat.Sample(catCtx, window)
 	if err != nil {
 		return nil, err
 	}

--- a/ai-observer/internal/scheduler/scheduler_test.go
+++ b/ai-observer/internal/scheduler/scheduler_test.go
@@ -39,7 +39,8 @@ func TestBudget_Reset(t *testing.T) {
 func TestScheduler_RunOnce_NoCategories(t *testing.T) {
 	t.Helper()
 	s := scheduler.New(
-		nil,
+		nil, // fast categories
+		nil, // slow categories
 		nil,
 		nil,
 		scheduler.Config{
@@ -54,4 +55,49 @@ func TestScheduler_RunOnce_NoCategories(t *testing.T) {
 
 	// Should return without panic when there are no categories
 	s.RunOnce(ctx)
+}
+
+func TestScheduler_DualTicker_Config(t *testing.T) {
+	t.Helper()
+
+	const (
+		fastInterval = 30
+		slowInterval = 21600
+		tokenBudget  = 1000
+		driftHours   = 6
+	)
+
+	cfg := scheduler.Config{
+		IntervalSeconds:      fastInterval,
+		MaxTokensPerInterval: tokenBudget,
+		WindowDuration:       time.Hour,
+		DryRun:               false,
+		DriftIntervalSeconds: slowInterval,
+		DriftWindowDuration:  driftHours * time.Hour,
+	}
+	s := scheduler.New(nil, nil, nil, nil, cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	s.RunOnce(ctx)
+}
+
+func TestScheduler_RunDrift_NoCategories(t *testing.T) {
+	t.Helper()
+	s := scheduler.New(
+		nil, // fast categories
+		nil, // slow categories
+		nil,
+		nil,
+		scheduler.Config{
+			IntervalSeconds:      1,
+			MaxTokensPerInterval: 0,
+			WindowDuration:       time.Hour,
+			DryRun:               false,
+		},
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Should return without panic when there are no slow categories
+	s.RunDrift(ctx)
 }


### PR DESCRIPTION
## Summary
- New `category/drift/` package implementing Category interface for drift detection
- Bootstrap wiring: config extension (7 drift env vars), baseline mapping, category construction
- Dual-ticker scheduler: fast (30min) for classifier, slow (6h) for drift
- LLM analyzer invoked only on threshold breach

## Test plan
- [x] `go test ./... -v` — all tests pass
- [x] `golangci-lint run` — 0 issues
- [ ] Integration testing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)