### PR TITLE
fix(crawler): use dedicated indigenous endpoint in backfill to bypass pagination limit

### DIFF
--- a/crawler/internal/admin/backfill_indigenous.go
+++ b/crawler/internal/admin/backfill_indigenous.go
@@ -74,14 +74,14 @@ func (h *BackfillIndigenousHandler) BackfillIndigenous(c *gin.Context) {
 	dryRun := c.Query("dry_run") == "true"
 	limit := ParseBackfillLimit(c.Query("limit"))
 
-	allSources, err := h.SourcesClient.ListSources(ctx)
+	allIndigenous, err := h.SourcesClient.ListIndigenousSources(ctx)
 	if err != nil {
-		h.Logger.Error("Failed to list sources for backfill", infralogger.Error(err))
+		h.Logger.Error("Failed to list indigenous sources for backfill", infralogger.Error(err))
 		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to list sources"})
 		return
 	}
 
-	indigenous := FilterIndigenousSources(allSources, region, limit)
+	indigenous := FilterIndigenousSources(allIndigenous, region, limit)
 
 	report := h.buildReport(ctx, indigenous, region, dryRun)
 

--- a/crawler/internal/job/event_service_test.go
+++ b/crawler/internal/job/event_service_test.go
@@ -148,6 +148,11 @@ func (m *MockSourceClient) ListSources(_ context.Context) ([]*sources.SourceList
 	return result, nil
 }
 
+// ListIndigenousSources returns an empty slice for MockSourceClient.
+func (m *MockSourceClient) ListIndigenousSources(_ context.Context) ([]*sources.SourceListItem, error) {
+	return []*sources.SourceListItem{}, nil
+}
+
 // AddSource adds a source to the mock.
 func (m *MockSourceClient) AddSource(s *sources.Source) {
 	m.sources[s.ID] = s

--- a/crawler/internal/sources/client.go
+++ b/crawler/internal/sources/client.go
@@ -42,6 +42,7 @@ type SourceListItem struct {
 type Client interface {
 	GetSource(ctx context.Context, sourceID uuid.UUID) (*Source, error)
 	ListSources(ctx context.Context) ([]*SourceListItem, error)
+	ListIndigenousSources(ctx context.Context) ([]*SourceListItem, error)
 }
 
 // HTTPClient implements Client using HTTP requests to source-manager.
@@ -50,9 +51,10 @@ type HTTPClient struct {
 	httpClient *http.Client
 }
 
-// Default timeouts for HTTP client.
+// Default timeouts and limits for HTTP client.
 const (
-	defaultHTTPTimeout = 10 * time.Second
+	defaultHTTPTimeout     = 10 * time.Second
+	indigenousSourcesLimit = 500
 )
 
 // NewHTTPClient creates a new HTTP client for source-manager.
@@ -134,6 +136,39 @@ func (c *HTTPClient) ListSources(ctx context.Context) ([]*SourceListItem, error)
 	return payload.Sources, nil
 }
 
+// ListIndigenousSources fetches all indigenous sources from the dedicated source-manager endpoint.
+// It calls /api/v1/sources/indigenous with a high limit to bypass the default pagination cap.
+func (c *HTTPClient) ListIndigenousSources(ctx context.Context) ([]*SourceListItem, error) {
+	url := fmt.Sprintf("%s/api/v1/sources/indigenous?limit=%d", c.baseURL, indigenousSourcesLimit)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch indigenous sources: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+
+	var payload struct {
+		Sources []*SourceListItem `json:"sources"`
+	}
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&payload); decodeErr != nil {
+		return nil, fmt.Errorf("decode response: %w", decodeErr)
+	}
+
+	if payload.Sources == nil {
+		payload.Sources = []*SourceListItem{}
+	}
+	return payload.Sources, nil
+}
+
 // NoOpClient is a client that always returns nil (for testing/disabled mode).
 type NoOpClient struct{}
 
@@ -149,5 +184,10 @@ func (c *NoOpClient) GetSource(_ context.Context, _ uuid.UUID) (*Source, error) 
 
 // ListSources always returns an empty slice for NoOpClient.
 func (c *NoOpClient) ListSources(_ context.Context) ([]*SourceListItem, error) {
+	return []*SourceListItem{}, nil
+}
+
+// ListIndigenousSources always returns an empty slice for NoOpClient.
+func (c *NoOpClient) ListIndigenousSources(_ context.Context) ([]*SourceListItem, error) {
 	return []*SourceListItem{}, nil
 }


### PR DESCRIPTION
## Summary

- Adds `ListIndigenousSources()` to the `sources.Client` interface, calling `GET /api/v1/sources/indigenous?limit=500` directly
- Updates `BackfillIndigenousHandler` to call `ListIndigenousSources()` instead of `ListSources()` + client-side filtering
- Adds `ListIndigenousSources()` stub to `NoOpClient` and `MockSourceClient`

Fixes #232 — backfill was only seeing ~20 of 186 indigenous sources because `ListSources()` caps at the default page size of 100.

## Test plan

- [ ] All existing crawler tests pass (`task test:crawler`)
- [ ] Linter clean (`task lint:crawler`)
- [ ] Production backfill dispatches all 186 indigenous sources (verify `jobs_dispatched` in response matches `sources_found`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)