### PR TITLE
test(crawler): add HTTP-level tests for ListIndigenousSources

### DIFF
--- a/crawler/internal/sources/client_test.go
+++ b/crawler/internal/sources/client_test.go
@@ -110,7 +110,7 @@ func TestListIndigenousSources_ReturnsSources(t *testing.T) {
 func TestListIndigenousSources_NullSources_ReturnsEmptySlice(t *testing.T) {
 	t.Helper()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Helper()
 		fmt.Fprint(w, `{"sources":null,"total":0}`)
 	}))


### PR DESCRIPTION
## Summary

Closes #242.

Adds three `httptest`-based tests for `HTTPClient.ListIndigenousSources`:

- Correct path (`/api/v1/sources/indigenous`) and `limit=500` query param are sent
- Sources decoded correctly from `{"sources":[...],"total":N}` response
- `null` sources in response returns empty slice (not nil)
- Non-200 status code returns an error

## Test plan

- [ ] `task test:crawler` passes
- [ ] `task lint:crawler` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)