### PR TITLE
feat(render-worker): add unit tests and extract handler module

### DIFF
--- a/render-worker/handler.js
+++ b/render-worker/handler.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const MAX_BODY_BYTES = 1024 * 1024; // 1 MB request body limit
+const MAX_QUEUE_DEPTH = 50; // reject with 503 when queue exceeds this
+
+/**
+ * Creates the HTTP request handler for the render worker.
+ * @param {object} state - Shared mutable state (browser, requestCount, queueDepth, queue).
+ * @param {Function} processQueue - Function to drain the render queue.
+ * @returns {Function} Node.js http.Server request handler.
+ */
+function createRequestHandler(state, processQueue) {
+  return function requestHandler(req, res) {
+    if (req.method === 'GET' && req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        browser_connected: state.browser ? state.browser.isConnected() : false,
+        request_count: state.requestCount,
+        queue_depth: state.queueDepth,
+        recycle_after: state.recycleAfter,
+      }));
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/render') {
+      let data = '';
+      let bodySize = 0;
+      req.on('data', (chunk) => {
+        bodySize += chunk.length;
+        if (bodySize > MAX_BODY_BYTES) {
+          res.writeHead(413, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'request body too large' }));
+          req.destroy();
+          return;
+        }
+        data += chunk;
+      });
+      req.on('end', () => {
+        if (bodySize > MAX_BODY_BYTES) return;
+        try {
+          const body = JSON.parse(data);
+          if (!body.url) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'url is required' }));
+            return;
+          }
+          if (state.queue.length >= MAX_QUEUE_DEPTH) {
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'queue full, try again later' }));
+            return;
+          }
+          state.queue.push({ res, body });
+          state.queueDepth = state.queue.length;
+          processQueue();
+        } catch (_err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid JSON' }));
+        }
+      });
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  };
+}
+
+module.exports = { createRequestHandler, MAX_BODY_BYTES, MAX_QUEUE_DEPTH };

--- a/render-worker/index.js
+++ b/render-worker/index.js
@@ -1,33 +1,37 @@
+'use strict';
+
 const http = require('http');
 const { chromium } = require('playwright');
+const { createRequestHandler } = require('./handler');
 
 const PORT = process.env.PORT || 3000;
-const MAX_CONCURRENT = parseInt(process.env.MAX_CONCURRENT_TABS || '1', 10);
 const RECYCLE_AFTER = parseInt(process.env.BROWSER_RECYCLE_AFTER || '100', 10);
 const DEFAULT_TIMEOUT = parseInt(process.env.DEFAULT_TIMEOUT_MS || '15000', 10);
-const MAX_BODY_BYTES = 1024 * 1024; // 1 MB request body limit
-const MAX_QUEUE_DEPTH = 50; // reject with 503 when queue exceeds this
 
-let browser = null;
-let requestCount = 0;
-let queueDepth = 0;
+const state = {
+  browser: null,
+  requestCount: 0,
+  queueDepth: 0,
+  queue: [],
+  recycleAfter: RECYCLE_AFTER,
+};
+
 let processing = false;
-const queue = [];
 
 async function ensureBrowser() {
-  if (!browser || !browser.isConnected()) {
-    browser = await chromium.launch({
+  if (!state.browser || !state.browser.isConnected()) {
+    state.browser = await chromium.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
     });
-    requestCount = 0;
+    state.requestCount = 0;
   }
-  return browser;
+  return state.browser;
 }
 
 async function recycleBrowserIfNeeded() {
-  if (requestCount >= RECYCLE_AFTER && browser) {
-    await browser.close().catch(() => {});
-    browser = null;
+  if (state.requestCount >= RECYCLE_AFTER && state.browser) {
+    await state.browser.close().catch(() => {});
+    state.browser = null;
   }
 }
 
@@ -54,16 +58,16 @@ async function renderPage(url, timeoutMs, waitUntil) {
   } finally {
     await page.close().catch(() => {});
     await context.close().catch(() => {});
-    requestCount++;
+    state.requestCount++;
     await recycleBrowserIfNeeded();
   }
 }
 
 function processQueue() {
-  if (processing || queue.length === 0) return;
+  if (processing || state.queue.length === 0) return;
   processing = true;
-  const { req, res, body } = queue.shift();
-  queueDepth = queue.length;
+  const { res, body } = state.queue.shift();
+  state.queueDepth = state.queue.length;
 
   renderPage(body.url, body.timeout_ms || DEFAULT_TIMEOUT, body.wait_until)
     .then((result) => {
@@ -80,60 +84,7 @@ function processQueue() {
     });
 }
 
-const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/health') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({
-      status: 'ok',
-      browser_connected: browser ? browser.isConnected() : false,
-      request_count: requestCount,
-      queue_depth: queueDepth,
-      recycle_after: RECYCLE_AFTER,
-    }));
-    return;
-  }
-
-  if (req.method === 'POST' && req.url === '/render') {
-    let data = '';
-    let bodySize = 0;
-    req.on('data', (chunk) => {
-      bodySize += chunk.length;
-      if (bodySize > MAX_BODY_BYTES) {
-        res.writeHead(413, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'request body too large' }));
-        req.destroy();
-        return;
-      }
-      data += chunk;
-    });
-    req.on('end', () => {
-      if (bodySize > MAX_BODY_BYTES) return;
-      try {
-        const body = JSON.parse(data);
-        if (!body.url) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'url is required' }));
-          return;
-        }
-        if (queue.length >= MAX_QUEUE_DEPTH) {
-          res.writeHead(503, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'queue full, try again later' }));
-          return;
-        }
-        queue.push({ req, res, body });
-        queueDepth = queue.length;
-        processQueue();
-      } catch (err) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'invalid JSON' }));
-      }
-    });
-    return;
-  }
-
-  res.writeHead(404, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({ error: 'not found' }));
-});
+const server = http.createServer(createRequestHandler(state, processQueue));
 
 server.listen(PORT, () => {
   console.log(`render-worker listening on port ${PORT}`);
@@ -142,7 +93,7 @@ server.listen(PORT, () => {
 
 process.on('SIGTERM', async () => {
   console.log('shutting down');
-  if (browser) await browser.close().catch(() => {});
+  if (state.browser) await state.browser.close().catch(() => {});
   server.close();
   process.exit(0);
 });

--- a/render-worker/package.json
+++ b/render-worker/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo 'no tests yet'"
+    "test": "node --test test.js"
   },
   "dependencies": {
     "playwright": "1.52.0"

--- a/render-worker/test.js
+++ b/render-worker/test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { createRequestHandler, MAX_QUEUE_DEPTH } = require('./handler');
+
+// Build a minimal state object and no-op processQueue for tests that don't need rendering.
+function makeState(overrides) {
+  return {
+    browser: null,
+    requestCount: 0,
+    queueDepth: 0,
+    queue: [],
+    recycleAfter: 100,
+    ...overrides,
+  };
+}
+
+// Helper: start a test server with the given state and processQueue stub.
+function startServer(state, processQueue) {
+  const handler = createRequestHandler(state, processQueue || (() => {}));
+  const server = http.createServer(handler);
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server)));
+}
+
+// Helper: make an HTTP request, returns { status, body }.
+function request(server, method, path, payload) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const body = payload !== undefined ? JSON.stringify(payload) : undefined;
+    const opts = {
+      host: '127.0.0.1',
+      port: addr.port,
+      method,
+      path,
+      headers: body ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) } : {},
+    };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(data) }); }
+        catch { resolve({ status: res.statusCode, body: data }); }
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+// Helper: send raw bytes as POST /render body.
+function requestRaw(server, rawBody) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const opts = {
+      host: '127.0.0.1',
+      port: addr.port,
+      method: 'POST',
+      path: '/render',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(rawBody) },
+    };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(data) }); }
+        catch { resolve({ status: res.statusCode, body: data }); }
+      });
+    });
+    req.on('error', reject);
+    req.write(rawBody);
+    req.end();
+  });
+}
+
+test('GET /health returns ok status with expected fields', async () => {
+  const state = makeState({ requestCount: 5, queueDepth: 2, recycleAfter: 50 });
+  const server = await startServer(state);
+  try {
+    const { status, body } = await request(server, 'GET', '/health');
+    assert.equal(status, 200);
+    assert.equal(body.status, 'ok');
+    assert.equal(body.browser_connected, false);
+    assert.equal(body.request_count, 5);
+    assert.equal(body.queue_depth, 2);
+    assert.equal(body.recycle_after, 50);
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /unknown returns 404', async () => {
+  const server = await startServer(makeState());
+  try {
+    const { status, body } = await request(server, 'GET', '/unknown');
+    assert.equal(status, 404);
+    assert.equal(body.error, 'not found');
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /render with missing url returns 400', async () => {
+  const server = await startServer(makeState());
+  try {
+    const { status, body } = await request(server, 'POST', '/render', { wait_until: 'load' });
+    assert.equal(status, 400);
+    assert.equal(body.error, 'url is required');
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /render with invalid JSON returns 400', async () => {
+  const server = await startServer(makeState());
+  try {
+    const { status, body } = await requestRaw(server, '{not valid json}');
+    assert.equal(status, 400);
+    assert.equal(body.error, 'invalid JSON');
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /render with full queue returns 503', async () => {
+  const state = makeState();
+  // Pre-fill queue to capacity with dummy entries.
+  for (let i = 0; i < MAX_QUEUE_DEPTH; i++) {
+    state.queue.push({ res: null, body: { url: `http://example.com/${i}` } });
+  }
+  const server = await startServer(state);
+  try {
+    const { status, body } = await request(server, 'POST', '/render', { url: 'http://example.com/new' });
+    assert.equal(status, 503);
+    assert.equal(body.error, 'queue full, try again later');
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary

Closes #189.

### Changes

**`handler.js` (new)** — Extracts HTTP routing from `index.js` into its own module using dependency injection (state object + `processQueue` callback). No playwright dependency — fully testable in isolation.

**`index.js` (refactored)** — Wires `handler.js` with playwright browser management. Startup behaviour is unchanged. Also fixed a bug: `req` was destructured from `queue.shift()` but never used — removed it.

**`test.js` (new)** — 5 tests using Node.js built-in `node:test`, no browser required:
- `GET /health` → 200 with all expected fields
- `GET /unknown` → 404
- `POST /render` missing url → 400
- `POST /render` invalid JSON → 400
- `POST /render` queue full → 503

**`package.json`** — Test script changed from `echo` placeholder to `node --test test.js`.

## Test plan

- [ ] `npm test` passes in `render-worker/` (no browser needed)
- [ ] `docker compose ... up -d --build render-worker` still starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)