### PR TITLE
feat(crawler): scoring-based page type classifier with HTML signals

### DIFF
--- a/crawler/internal/content/rawcontent/export_test.go
+++ b/crawler/internal/content/rawcontent/export_test.go
@@ -25,6 +25,9 @@ var TemplateRegistry = templateRegistry
 // ClassifyPageType exports classifyPageType for testing.
 var ClassifyPageType = classifyPageType
 
+// ExtractHTMLSignals exports extractHTMLSignals for testing.
+var ExtractHTMLSignals = extractHTMLSignals
+
 // Exported page type constants for testing.
 const (
 	PageTypeArticle = pageTypeArticle
@@ -32,3 +35,26 @@ const (
 	PageTypeListing = pageTypeListing
 	PageTypeOther   = pageTypeOther
 )
+
+// MakeSignals constructs a pageTypeSignals for use in external test packages.
+// Only the fields needed for the test case need to be specified; zero values
+// are safe defaults (empty strings, false, 0).
+func MakeSignals(
+	title string,
+	wordCount, linkCount int,
+	ogType, detectedContentType, jsonLDType string,
+	articleTagCount int,
+	hasDateTime, hasSignInText bool,
+) pageTypeSignals {
+	return pageTypeSignals{
+		title:               title,
+		wordCount:           wordCount,
+		linkCount:           linkCount,
+		ogType:              ogType,
+		detectedContentType: detectedContentType,
+		jsonLDType:          jsonLDType,
+		articleTagCount:     articleTagCount,
+		hasDateTime:         hasDateTime,
+		hasSignInText:       hasSignInText,
+	}
+}

--- a/crawler/internal/content/rawcontent/page_type.go
+++ b/crawler/internal/content/rawcontent/page_type.go
@@ -1,5 +1,7 @@
 package rawcontent
 
+import "strings"
+
 // Page type constants classify the structural nature of a crawled page.
 const (
 	pageTypeArticle = "article"
@@ -8,7 +10,7 @@ const (
 	pageTypeOther   = "other"
 )
 
-// Thresholds for page type classification heuristics.
+// Word/link thresholds for page type classification.
 const (
 	articleMinWordCount   = 200
 	stubMaxWordCount      = 50
@@ -16,21 +18,123 @@ const (
 	listingMaxWordPerLink = 10
 )
 
-// classifyPageType assigns a page type based on title presence, word count, and link density.
-func classifyPageType(title string, wordCount, linkCount int) string {
-	hasTitle := title != ""
+// Scoring weights for article signals.
+const (
+	scoreJSONLDArticle       = 5
+	scoreOGTypeArticle       = 3
+	scoreDetectedTypeArticle = 3
+	scoreArticleTag          = 2
+	scoreDateTime            = 1
+	scoreWordCountTitle      = 4
+	articleScoreThreshold    = 4
+)
 
-	if hasTitle && wordCount >= articleMinWordCount {
+// jsonLDArticleTypes are schema.org types that indicate article content.
+var jsonLDArticleTypes = map[string]bool{
+	"article":     true,
+	"newsarticle": true,
+	"blogposting": true,
+	"reportage":   true,
+}
+
+// pageTypeSignals holds all signals used to classify a page's structural type.
+type pageTypeSignals struct {
+	title               string
+	wordCount           int
+	linkCount           int
+	ogType              string
+	detectedContentType string
+	jsonLDType          string
+	articleTagCount     int
+	hasDateTime         bool
+	hasSignInText       bool
+}
+
+// classifyPageType assigns a page type from a scored set of structural signals.
+// Sign-in pages are always "other". Otherwise article, listing, stub, or other
+// is chosen in order of decreasing specificity.
+func classifyPageType(s pageTypeSignals) string {
+	if s.hasSignInText {
+		return pageTypeOther
+	}
+
+	if computeArticleScore(s) >= articleScoreThreshold {
 		return pageTypeArticle
 	}
 
-	if hasTitle && wordCount < stubMaxWordCount {
-		return pageTypeStub
-	}
-
-	if linkCount >= listingMinLinkCount && (wordCount == 0 || wordCount/linkCount < listingMaxWordPerLink) {
+	if isListingPage(s.linkCount, s.wordCount) {
 		return pageTypeListing
 	}
 
+	if s.title != "" && s.wordCount < stubMaxWordCount {
+		return pageTypeStub
+	}
+
 	return pageTypeOther
+}
+
+// computeArticleScore sums weighted signals that indicate article content.
+func computeArticleScore(s pageTypeSignals) int {
+	score := 0
+
+	if jsonLDArticleTypes[strings.ToLower(s.jsonLDType)] {
+		score += scoreJSONLDArticle
+	}
+
+	if strings.EqualFold(s.ogType, "article") {
+		score += scoreOGTypeArticle
+	}
+
+	if strings.EqualFold(s.detectedContentType, "article") {
+		score += scoreDetectedTypeArticle
+	}
+
+	if s.articleTagCount > 0 {
+		score += scoreArticleTag
+	}
+
+	if s.hasDateTime {
+		score += scoreDateTime
+	}
+
+	if s.title != "" && s.wordCount >= articleMinWordCount {
+		score += scoreWordCountTitle
+	}
+
+	return score
+}
+
+// isListingPage returns true when links are dense relative to word count.
+func isListingPage(linkCount, wordCount int) bool {
+	return linkCount >= listingMinLinkCount &&
+		(wordCount == 0 || wordCount/linkCount < listingMaxWordPerLink)
+}
+
+// extractHTMLSignals scans rawHTML for structural signals without full parsing.
+// Returns the number of <article> elements, whether a <time datetime= attribute
+// is present, and whether sign-in language is detected.
+func extractHTMLSignals(rawHTML string) (articleTagCount int, hasDateTime, hasSignInText bool) {
+	lower := strings.ToLower(rawHTML)
+	articleTagCount = strings.Count(lower, "<article")
+	hasDateTime = strings.Contains(lower, "<time datetime")
+	hasSignInText = strings.Contains(lower, "sign in") ||
+		strings.Contains(lower, "log in") ||
+		strings.Contains(lower, "sign-in")
+	return
+}
+
+// extractJSONLDType returns the @type value from a JSON-LD data map, or "".
+func extractJSONLDType(data map[string]any) string {
+	if data == nil {
+		return ""
+	}
+	v, ok := data["@type"]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }

--- a/crawler/internal/content/rawcontent/page_type_test.go
+++ b/crawler/internal/content/rawcontent/page_type_test.go
@@ -10,29 +10,129 @@ func TestClassifyPageType(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		title     string
-		wordCount int
-		linkCount int
-		want      string
+		name                string
+		title               string
+		wordCount           int
+		linkCount           int
+		ogType              string
+		detectedContentType string
+		jsonLDType          string
+		articleTagCount     int
+		hasDateTime         bool
+		hasSignInText       bool
+		want                string
 	}{
-		{"article with content", "Breaking News", 350, 5, rawcontent.PageTypeArticle},
-		{"article at threshold", "Story", 200, 3, rawcontent.PageTypeArticle},
-		{"stub with title", "Headline", 20, 2, rawcontent.PageTypeStub},
-		{"stub empty body", "Title Only", 0, 1, rawcontent.PageTypeStub},
-		{"listing page", "", 100, 30, rawcontent.PageTypeListing},
-		{"listing high link ratio", "News", 50, 25, rawcontent.PageTypeListing},
-		{"other no title", "", 100, 5, rawcontent.PageTypeOther},
-		{"other low content", "", 80, 8, rawcontent.PageTypeOther},
+		// Word count + title (score=4 from scoreWordCountTitle)
+		{name: "article high word count", title: "Breaking News", wordCount: 350, want: rawcontent.PageTypeArticle},
+		{name: "article at word threshold", title: "Story", wordCount: 200, want: rawcontent.PageTypeArticle},
+		// OG type combined with word count
+		{name: "article og type and word count", title: "Event", wordCount: 250, ogType: "article", want: rawcontent.PageTypeArticle},
+		// JSON-LD signals alone exceed threshold (score=5)
+		{name: "article newsarticle jsonld", title: "Piece", wordCount: 50, jsonLDType: "NewsArticle", want: rawcontent.PageTypeArticle},
+		{name: "article blogposting jsonld", jsonLDType: "BlogPosting", want: rawcontent.PageTypeArticle},
+		// HTML structural signals
+		{name: "article tag plus word count", title: "News", wordCount: 200, articleTagCount: 1, want: rawcontent.PageTypeArticle},
+		{
+			name: "article tag plus datetime via jsonld", title: "Piece",
+			jsonLDType: "Article", articleTagCount: 2, hasDateTime: true,
+			want: rawcontent.PageTypeArticle,
+		},
+		// Sign-in override always returns other
+		{name: "sign-in page overrides article signals", title: "Login", wordCount: 500, hasSignInText: true, want: rawcontent.PageTypeOther},
+		// Stub: has title, word count below threshold
+		{name: "stub with title", title: "Headline", wordCount: 20, want: rawcontent.PageTypeStub},
+		{name: "stub empty body", title: "Title Only", wordCount: 0, want: rawcontent.PageTypeStub},
+		// Listing: many links, low word-per-link ratio
+		{name: "listing page", wordCount: 100, linkCount: 30, want: rawcontent.PageTypeListing},
+		{name: "listing high link ratio", title: "News", wordCount: 50, linkCount: 25, want: rawcontent.PageTypeListing},
+		// Other: insufficient signals for any positive classification
+		{name: "other no title", wordCount: 100, linkCount: 5, want: rawcontent.PageTypeOther},
+		{name: "other low content", wordCount: 80, linkCount: 8, want: rawcontent.PageTypeOther},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := rawcontent.ClassifyPageType(tt.title, tt.wordCount, tt.linkCount)
+			got := rawcontent.ClassifyPageType(rawcontent.MakeSignals(
+				tt.title,
+				tt.wordCount, tt.linkCount,
+				tt.ogType, tt.detectedContentType, tt.jsonLDType,
+				tt.articleTagCount,
+				tt.hasDateTime, tt.hasSignInText,
+			))
 			if got != tt.want {
-				t.Errorf("ClassifyPageType(%q, %d, %d) = %q, want %q",
-					tt.title, tt.wordCount, tt.linkCount, got, tt.want)
+				t.Errorf("classifyPageType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractHTMLSignals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		html              string
+		wantArticleTags   int
+		wantHasDateTime   bool
+		wantHasSignInText bool
+	}{
+		{
+			name:            "no signals",
+			html:            "<p>Some content here</p>",
+			wantArticleTags: 0, wantHasDateTime: false, wantHasSignInText: false,
+		},
+		{
+			name:            "single article tag",
+			html:            `<article class="post"><p>Content</p></article>`,
+			wantArticleTags: 1, wantHasDateTime: false, wantHasSignInText: false,
+		},
+		{
+			name:            "multiple article tags",
+			html:            `<article>A</article><article>B</article>`,
+			wantArticleTags: 2, wantHasDateTime: false, wantHasSignInText: false,
+		},
+		{
+			name:            "datetime attribute",
+			html:            `<time datetime="2026-01-15">Jan 15</time>`,
+			wantArticleTags: 0, wantHasDateTime: true, wantHasSignInText: false,
+		},
+		{
+			name:            "sign in text",
+			html:            `<a href="/login">Sign In</a>`,
+			wantArticleTags: 0, wantHasDateTime: false, wantHasSignInText: true,
+		},
+		{
+			name:            "log in text",
+			html:            `<button>Log in to continue</button>`,
+			wantArticleTags: 0, wantHasDateTime: false, wantHasSignInText: true,
+		},
+		{
+			name:            "sign-in hyphenated",
+			html:            `<div class="sign-in-wall">Subscribe</div>`,
+			wantArticleTags: 0, wantHasDateTime: false, wantHasSignInText: true,
+		},
+		{
+			name:              "all signals present",
+			html:              `<article><time datetime="2026-03-01">Mar 1</time><p>Content</p></article><a>Sign in</a>`,
+			wantArticleTags:   1,
+			wantHasDateTime:   true,
+			wantHasSignInText: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotTags, gotDateTime, gotSignIn := rawcontent.ExtractHTMLSignals(tt.html)
+			if gotTags != tt.wantArticleTags {
+				t.Errorf("articleTagCount = %d, want %d", gotTags, tt.wantArticleTags)
+			}
+			if gotDateTime != tt.wantHasDateTime {
+				t.Errorf("hasDateTime = %v, want %v", gotDateTime, tt.wantHasDateTime)
+			}
+			if gotSignIn != tt.wantHasSignInText {
+				t.Errorf("hasSignInText = %v, want %v", gotSignIn, tt.wantHasSignInText)
 			}
 		})
 	}

--- a/crawler/internal/content/rawcontent/service.go
+++ b/crawler/internal/content/rawcontent/service.go
@@ -411,7 +411,18 @@ func (s *RawContentService) convertToRawContent(
 
 	// Tag page type for extraction quality measurement
 	linkCount := strings.Count(rawData.RawHTML, "<a ")
-	pageType := classifyPageType(rawData.Title, wordCount, linkCount)
+	articleTagCount, hasDateTime, hasSignInText := extractHTMLSignals(rawData.RawHTML)
+	pageType := classifyPageType(pageTypeSignals{
+		title:               rawData.Title,
+		wordCount:           wordCount,
+		linkCount:           linkCount,
+		ogType:              ogType,
+		detectedContentType: detectedContentType,
+		jsonLDType:          extractJSONLDType(rawData.JSONLDData),
+		articleTagCount:     articleTagCount,
+		hasDateTime:         hasDateTime,
+		hasSignInText:       hasSignInText,
+	})
 	meta["page_type"] = pageType
 
 	rawContent := &storagepkg.RawContent{


### PR DESCRIPTION
Closes #172

## Summary

- Replaces the simple word-count/link-density threshold logic in `classifyPageType` with a weighted scoring approach
- New `pageTypeSignals` struct captures all available signals: JSON-LD `@type`, `og:type`, detected content type, `<article>` tag count, `<time datetime>` presence, and sign-in text detection
- Sign-in pages always return `"other"` regardless of other signals (strong negative override)
- `extractHTMLSignals` does lightweight string scanning — no full HTML parser dependency
- `extractJSONLDType` reads schema.org type from already-extracted JSON-LD map
- Call site in `convertToRawContent` now passes all available signals

## Scoring weights

| Signal | Points |
|---|---|
| JSON-LD @type is Article/NewsArticle/BlogPosting/Reportage | +5 |
| og:type = "article" | +3 |
| detectedContentType = "article" | +3 |
| `<article>` tag present | +2 |
| `<time datetime>` present | +1 |
| title + wordCount ≥ 200 | +4 |
| sign-in text detected | always → "other" |

Threshold to classify as article: ≥ 4 points.

## Test plan

- [x] `TestClassifyPageType` — 14 cases covering all scoring paths and overrides
- [x] `TestExtractHTMLSignals` — 8 cases for article tags, datetime, sign-in variants
- [x] `task lint:crawler` passes (0 issues)
- [x] `task test:crawler` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)