### PR TITLE
feat(crawler): CMS template registry with WordPress, Drupal, and HTML detection

### DIFF
--- a/crawler/internal/content/rawcontent/export_test.go
+++ b/crawler/internal/content/rawcontent/export_test.go
@@ -19,6 +19,12 @@ var ExtractJSONLDHeadline = extractJSONLDHeadline
 // LookupTemplate exports lookupTemplate for testing.
 var LookupTemplate = lookupTemplate
 
+// LookupTemplateByName exports lookupTemplateByName for testing.
+var LookupTemplateByName = lookupTemplateByName
+
+// DetectTemplateByHTML exports detectTemplateByHTML for testing.
+var DetectTemplateByHTML = detectTemplateByHTML
+
 // TemplateRegistry exports templateRegistry for testing.
 var TemplateRegistry = templateRegistry
 

--- a/crawler/internal/content/rawcontent/service.go
+++ b/crawler/internal/content/rawcontent/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gocolly/colly/v2"
@@ -45,6 +46,7 @@ type RawContentService struct {
 	pipeline                   *pipeline.Client
 	recorder                   ExtractionRecorder // optional; set at crawl start for extraction quality metrics
 	readabilityFallbackEnabled bool
+	templateExtractions        int64 // atomic; incremented each time a CMS template provides selectors
 }
 
 // NewRawContentService creates a new raw content service.
@@ -72,6 +74,13 @@ func (s *RawContentService) SetExtractionRecorder(r ExtractionRecorder) {
 	s.recorder = r
 }
 
+// GetTemplateExtractions returns the number of pages for which a CMS template
+// provided the extraction selectors during this crawl session.
+// Safe to call concurrently.
+func (s *RawContentService) GetTemplateExtractions() int64 {
+	return atomic.LoadInt64(&s.templateExtractions)
+}
+
 // Process implements the Interface for HTML element processing.
 // Extracts raw content from any HTML page and indexes it to raw_content.
 func (s *RawContentService) Process(e *colly.HTMLElement) error {
@@ -94,8 +103,10 @@ func (s *RawContentService) Process(e *colly.HTMLElement) error {
 		}
 	}
 
-	// Get source configuration to determine source name, selectors, and metadata
-	sourceName, selectors, indigenousRegion := s.getSourceConfig(sourceURL)
+	// Get source configuration to determine source name, selectors, and metadata.
+	// Pass raw HTML for fallback template detection (WordPress/Drupal generator meta tags).
+	rawHTML := string(e.Response.Body)
+	sourceName, selectors, indigenousRegion := s.getSourceConfig(sourceURL, rawHTML)
 
 	// Extract raw content using generic extractor
 	rawData := ExtractRawContent(
@@ -227,7 +238,7 @@ func (s *RawContentService) emitIndexedEvent(
 }
 
 // getSourceConfig gets the source configuration and returns source name, selectors, and indigenous region.
-func (s *RawContentService) getSourceConfig(sourceURL string) (
+func (s *RawContentService) getSourceConfig(sourceURL, rawHTML string) (
 	name string, sel SourceSelectors, indigenousRegion string,
 ) {
 	var sourceName string
@@ -276,14 +287,16 @@ func (s *RawContentService) getSourceConfig(sourceURL string) (
 		selectors.Exclude = sourceConfig.Selectors.Article.Exclude
 	}
 
-	// If source-manager has no selectors, try template registry by domain
+	// If source-manager has no selectors, resolve via template registry.
+	// Priority: TemplateHint (explicit) > domain lookup > HTML-based detection.
 	if selectors.Title == "" && selectors.Body == "" && selectors.Container == "" {
-		hostname := extractHostFromURL(sourceURL)
-		if tmpl, ok := lookupTemplate(hostname); ok {
+		tmpl, tmplName := s.resolveTemplate(sourceConfig, sourceURL, rawHTML)
+		if tmpl != nil {
 			selectors = tmpl.Selectors
+			atomic.AddInt64(&s.templateExtractions, 1)
 			s.logger.Debug("Using CMS template selectors",
 				infralogger.String("url", sourceURL),
-				infralogger.String("template", tmpl.Name))
+				infralogger.String("template", tmplName))
 		}
 	}
 
@@ -298,6 +311,37 @@ func (s *RawContentService) getSourceConfig(sourceURL string) (
 	}
 
 	return sourceName, selectors, region
+}
+
+// resolveTemplate returns the best-matching CMS template for a page, along with its name.
+// Lookup priority: TemplateHint (explicit override) > domain match > HTML detection.
+// If TemplateHint is set but not found in the registry, a warning is logged and lookup
+// falls through to domain and HTML detection. Returns nil if no template matches.
+func (s *RawContentService) resolveTemplate(
+	sourceConfig *sources.Config, sourceURL, rawHTML string,
+) (result *CMSTemplate, resultName string) {
+	// 1. TemplateHint: explicit name from source-manager config skips detection entirely.
+	if sourceConfig.TemplateHint != nil {
+		if found, ok := lookupTemplateByName(*sourceConfig.TemplateHint); ok {
+			return found, found.Name
+		}
+		s.logger.Warn("TemplateHint not found in registry",
+			infralogger.String("hint", *sourceConfig.TemplateHint),
+			infralogger.String("url", sourceURL))
+	}
+
+	// 2. Domain match: fast, exact lookup against known CMS domains.
+	hostname := extractHostFromURL(sourceURL)
+	if found, ok := lookupTemplate(hostname); ok {
+		return found, found.Name
+	}
+
+	// 3. HTML detection: generator meta tags and OG signals as last resort.
+	if found, ok := detectTemplateByHTML(rawHTML); ok {
+		return found, found.Name
+	}
+
+	return nil, ""
 }
 
 // SourceSelectors represents generic selectors for content extraction

--- a/crawler/internal/content/rawcontent/templates.go
+++ b/crawler/internal/content/rawcontent/templates.go
@@ -7,11 +7,21 @@ import (
 )
 
 // CMSTemplate defines known-good CSS selectors for a CMS platform.
+// Detect is an optional function that identifies the CMS from raw HTML
+// (e.g. generator meta tag); it is consulted when no domain match is found.
 type CMSTemplate struct {
 	Name      string
 	Domains   []string
+	Detect    func(html string) bool // optional; nil disables HTML-based detection
 	Selectors SourceSelectors
 }
+
+// htmlDetectSize is the number of bytes of HTML examined for generator meta tag
+// detection. The <head> section with meta tags is always within the first 4 KB.
+const htmlDetectSize = 4096
+
+// domainPreAllocFactor estimates map capacity from the template count.
+const domainPreAllocFactor = 4
 
 var templateRegistry = []CMSTemplate{
 	{
@@ -61,14 +71,50 @@ var templateRegistry = []CMSTemplate{
 			Title:     "h1",
 		},
 	},
+	{
+		Name: "wordpress",
+		Detect: func(html string) bool {
+			return strings.Contains(html, `name="generator" content="WordPress`)
+		},
+		Selectors: SourceSelectors{
+			Container: "article",
+			Body:      ".entry-content",
+			Title:     "h1.entry-title",
+		},
+	},
+	{
+		Name: "drupal",
+		Detect: func(html string) bool {
+			return strings.Contains(html, `name="generator" content="Drupal`)
+		},
+		Selectors: SourceSelectors{
+			Body:  ".field--name-body",
+			Title: "h1.page-title",
+		},
+	},
+	// generic_og_article MUST remain after wordpress and drupal in this slice.
+	// WordPress and Drupal pages often emit og:type=article + <article>, so they
+	// would match this entry first if it were ordered before their specific entries.
+	{
+		Name: "generic_og_article",
+		Detect: func(html string) bool {
+			lower := strings.ToLower(html)
+			hasOGArticle := strings.Contains(lower, `og:type" content="article"`) ||
+				strings.Contains(lower, `property="og:type" content="article"`)
+			return hasOGArticle && strings.Contains(lower, "<article")
+		},
+		Selectors: SourceSelectors{
+			Container: "article",
+			Body:      ".entry-content, [itemprop=articleBody]",
+		},
+	},
 }
-
-// domainPreAllocFactor is used to estimate the map capacity from the template count.
-const domainPreAllocFactor = 4
 
 var (
 	domainTemplateIndex map[string]*CMSTemplate
+	nameTemplateIndex   map[string]*CMSTemplate
 	domainIndexOnce     sync.Once
+	nameIndexOnce       sync.Once
 )
 
 // buildDomainIndex populates domainTemplateIndex from templateRegistry.
@@ -84,6 +130,17 @@ func buildDomainIndex() {
 	})
 }
 
+// buildNameIndex populates nameTemplateIndex from templateRegistry.
+func buildNameIndex() {
+	nameIndexOnce.Do(func() {
+		nameTemplateIndex = make(map[string]*CMSTemplate, len(templateRegistry))
+		for i := range templateRegistry {
+			tmpl := &templateRegistry[i]
+			nameTemplateIndex[tmpl.Name] = tmpl
+		}
+	})
+}
+
 // lookupTemplate returns the CMS template for the given domain, if one exists.
 func lookupTemplate(domain string) (*CMSTemplate, bool) {
 	if domain == "" {
@@ -92,6 +149,37 @@ func lookupTemplate(domain string) (*CMSTemplate, bool) {
 	buildDomainIndex()
 	tmpl, ok := domainTemplateIndex[domain]
 	return tmpl, ok
+}
+
+// lookupTemplateByName returns the CMS template with the given name, if one exists.
+// This is used when a TemplateHint is set on the source config.
+func lookupTemplateByName(name string) (*CMSTemplate, bool) {
+	if name == "" {
+		return nil, false
+	}
+	buildNameIndex()
+	tmpl, ok := nameTemplateIndex[name]
+	return tmpl, ok
+}
+
+// detectTemplateByHTML scans templates with Detect functions against the first
+// htmlDetectSize bytes of HTML and returns the first match. This is the lowest-
+// priority lookup, tried only after domain and name-hint lookups fail.
+func detectTemplateByHTML(html string) (*CMSTemplate, bool) {
+	if html == "" {
+		return nil, false
+	}
+	snippet := html
+	if len(snippet) > htmlDetectSize {
+		snippet = snippet[:htmlDetectSize]
+	}
+	for i := range templateRegistry {
+		tmpl := &templateRegistry[i]
+		if tmpl.Detect != nil && tmpl.Detect(snippet) {
+			return tmpl, true
+		}
+	}
+	return nil, false
 }
 
 // extractHostFromURL parses a URL and returns the hostname with "www." stripped.

--- a/crawler/internal/content/rawcontent/templates_test.go
+++ b/crawler/internal/content/rawcontent/templates_test.go
@@ -74,3 +74,93 @@ func TestTemplateSelectorsNotEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupTemplateByName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		hint         string
+		wantFound    bool
+		wantTemplate string
+	}{
+		{name: "postmedia by name", hint: "postmedia", wantFound: true, wantTemplate: "postmedia"},
+		{name: "wordpress by name", hint: "wordpress", wantFound: true, wantTemplate: "wordpress"},
+		{name: "drupal by name", hint: "drupal", wantFound: true, wantTemplate: "drupal"},
+		{name: "village_media by name", hint: "village_media", wantFound: true, wantTemplate: "village_media"},
+		{name: "unknown hint", hint: "unknown_cms", wantFound: false},
+		{name: "empty hint", hint: "", wantFound: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpl, ok := rawcontent.LookupTemplateByName(tc.hint)
+			if ok != tc.wantFound {
+				t.Fatalf("LookupTemplateByName(%q) found=%v, want %v", tc.hint, ok, tc.wantFound)
+			}
+			if tc.wantFound && tmpl.Name != tc.wantTemplate {
+				t.Errorf("LookupTemplateByName(%q) template=%q, want %q", tc.hint, tmpl.Name, tc.wantTemplate)
+			}
+		})
+	}
+}
+
+func TestDetectTemplateByHTML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		html         string
+		wantFound    bool
+		wantTemplate string
+	}{
+		{
+			name:         "wordpress generator meta",
+			html:         `<meta name="generator" content="WordPress 6.4">`,
+			wantFound:    true,
+			wantTemplate: "wordpress",
+		},
+		{
+			name:         "drupal generator meta",
+			html:         `<meta name="generator" content="Drupal 10">`,
+			wantFound:    true,
+			wantTemplate: "drupal",
+		},
+		{
+			name: "generic og article with article tag",
+			html: `<meta property="og:type" content="article">
+<article class="post">content</article>`,
+			wantFound:    true,
+			wantTemplate: "generic_og_article",
+		},
+		{
+			name:      "og article without article tag",
+			html:      `<meta property="og:type" content="article"><div class="post">content</div>`,
+			wantFound: false,
+		},
+		{
+			name:      "no signals",
+			html:      `<html><body><p>hello</p></body></html>`,
+			wantFound: false,
+		},
+		{
+			name:      "empty html",
+			html:      "",
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpl, ok := rawcontent.DetectTemplateByHTML(tc.html)
+			if ok != tc.wantFound {
+				t.Fatalf("DetectTemplateByHTML() found=%v, want %v (html: %q)", ok, tc.wantFound, tc.html)
+			}
+			if tc.wantFound && tmpl.Name != tc.wantTemplate {
+				t.Errorf("DetectTemplateByHTML() template=%q, want %q", tmpl.Name, tc.wantTemplate)
+			}
+		})
+	}
+}

--- a/crawler/internal/metrics/metrics.go
+++ b/crawler/internal/metrics/metrics.go
@@ -27,6 +27,9 @@ type Metrics struct {
 	RateLimitedRequests int64
 	// URLsSkipped is the number of URLs skipped by the URL pre-filter.
 	URLsSkipped int64
+	// TemplateExtractions is the number of pages where a CMS template
+	// (template registry or HTML detection) provided the extraction selectors.
+	TemplateExtractions int64
 }
 
 // NewMetrics creates a new Metrics instance with default values.

--- a/crawler/internal/sources/converter.go
+++ b/crawler/internal/sources/converter.go
@@ -94,6 +94,7 @@ func createConfigFromLoader(cfg loader.Config, rateLimit time.Duration, allowedD
 		PageIndex:      cfg.PageIndex,
 		Selectors:      createSelectorConfig(cfg.Selectors),
 		Rules:          configtypes.Rules{},
+		TemplateHint:   cfg.TemplateHint,
 	}
 }
 

--- a/crawler/internal/sources/loader/api_loader.go
+++ b/crawler/internal/sources/loader/api_loader.go
@@ -95,6 +95,7 @@ func convertAPISourceToConfig(apiSource *apiclient.APISource) (Config, error) {
 			List:    convertAPIListSelectors(apiSource.Selectors.List),
 			Page:    convertAPIPageSelectors(apiSource.Selectors.Page),
 		},
+		TemplateHint: apiSource.TemplateHint,
 	}, nil
 }
 

--- a/crawler/internal/sources/loader/loader.go
+++ b/crawler/internal/sources/loader/loader.go
@@ -35,6 +35,7 @@ type Config struct {
 	Selectors    SourceSelectors   `mapstructure:"selectors"`
 	UserAgent    string            `mapstructure:"user_agent"`
 	Headers      map[string]string `mapstructure:"headers"`
+	TemplateHint *string           `mapstructure:"template_hint"`
 }
 
 // SourceSelectors defines the selectors for a source.

--- a/crawler/internal/sources/types/types.go
+++ b/crawler/internal/sources/types/types.go
@@ -43,6 +43,9 @@ type SourceConfig struct {
 	Rules              types.Rules
 	ArticleURLPatterns []string
 	IndigenousRegion   string
+	// TemplateHint is an optional CMS template name from source-manager.
+	// When set, template lookup uses this name directly, skipping domain detection.
+	TemplateHint *string
 }
 
 // SelectorConfig defines the CSS selectors used for content extraction.


### PR DESCRIPTION
Closes #173

## Summary
- Adds WordPress and Drupal templates to the CMS registry, detected via `<meta name="generator">` signals in the first 4 KB of HTML
- Adds `generic_og_article` template detected via `og:type=article` + `<article>` tag presence
- Wires `TemplateHint` field from source-manager API through the full chain (`APISource` → `loader.Config` → `SourceConfig`), allowing explicit template override per source
- Template resolution priority: **TemplateHint** (explicit) → **domain match** → **HTML detection** → generic fallback

## Changes
- `templates.go`: new `Detect func(html string) bool` field on `CMSTemplate`; `lookupTemplateByName`, `detectTemplateByHTML`; WordPress, Drupal, `generic_og_article` entries
- `service.go`: `getSourceConfig` now accepts `rawHTML string`; delegates to `resolveTemplate` helper
- `sources/types`, `loader`, `converter`: `TemplateHint *string` wired end-to-end from API response
- `metrics.go`: adds `TemplateExtractions int64` field
- Tests: `TestLookupTemplateByName` (6 cases), `TestDetectTemplateByHTML` (6 cases)

## Test plan
- [ ] `GOWORK=off go test -mod=mod ./internal/content/rawcontent/...` passes
- [ ] `GOWORK=off go test -mod=mod ./...` passes (all crawler tests)
- [ ] `golangci-lint run` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)