### PR TITLE
fix(render-worker): add stealth mode to bypass headless browser detection (#224)

### DIFF
--- a/render-worker/Dockerfile
+++ b/render-worker/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.52.0-noble
 WORKDIR /app
 COPY package.json ./
 RUN npm install --production
-COPY index.js ./
+COPY handler.js stealth.js index.js ./
 
 EXPOSE 3000
 CMD ["node", "index.js"]

--- a/render-worker/index.js
+++ b/render-worker/index.js
@@ -3,6 +3,7 @@
 const http = require('http');
 const { chromium } = require('playwright');
 const { createRequestHandler } = require('./handler');
+const { STEALTH_INIT_SCRIPT } = require('./stealth');
 
 const PORT = process.env.PORT || 3000;
 const RECYCLE_AFTER = parseInt(process.env.BROWSER_RECYCLE_AFTER || '100', 10);
@@ -21,7 +22,12 @@ let processing = false;
 async function ensureBrowser() {
   if (!state.browser || !state.browser.isConnected()) {
     state.browser = await chromium.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-blink-features=AutomationControlled',
+      ],
     });
     state.requestCount = 0;
   }
@@ -41,6 +47,7 @@ async function renderPage(url, timeoutMs, waitUntil) {
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
   });
   const page = await context.newPage();
+  await page.addInitScript(STEALTH_INIT_SCRIPT);
 
   try {
     const start = Date.now();

--- a/render-worker/stealth.js
+++ b/render-worker/stealth.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Stealth init script injected into every Playwright page before navigation.
+ * Patches browser fingerprints that headless-detection systems check to avoid 403s:
+ *   - navigator.webdriver  → undefined   (automation flag)
+ *   - navigator.plugins    → non-empty   (headless has 0 plugins)
+ *   - navigator.languages  → ['en-US','en'] (headless is often empty)
+ */
+const STEALTH_INIT_SCRIPT = `
+  Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  Object.defineProperty(navigator, 'plugins', {
+    get: () => {
+      const plugins = [
+        { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+        { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
+        { name: 'Native Client', filename: 'internal-nacl-plugin', description: '' },
+      ];
+      plugins.refresh = () => {};
+      plugins.item = (i) => plugins[i] || null;
+      plugins.namedItem = (n) => plugins.find((p) => p.name === n) || null;
+      return plugins;
+    },
+  });
+  Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+`;
+
+module.exports = { STEALTH_INIT_SCRIPT };

--- a/render-worker/test.js
+++ b/render-worker/test.js
@@ -4,6 +4,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('node:http');
 const { createRequestHandler, MAX_QUEUE_DEPTH } = require('./handler');
+const { STEALTH_INIT_SCRIPT } = require('./stealth');
 
 // Build a minimal state object and no-op processQueue for tests that don't need rendering.
 function makeState(overrides) {
@@ -138,4 +139,24 @@ test('POST /render with full queue returns 503', async () => {
   } finally {
     server.close();
   }
+});
+
+test('STEALTH_INIT_SCRIPT patches navigator.webdriver, plugins, and languages', () => {
+  const vm = require('node:vm');
+
+  // Run the stealth script in an isolated vm context with a fake navigator object.
+  const ctx = { navigator: {}, Object };
+  vm.createContext(ctx);
+  vm.runInContext(STEALTH_INIT_SCRIPT, ctx);
+
+  // navigator.webdriver should be undefined (not true)
+  assert.equal(Object.getOwnPropertyDescriptor(ctx.navigator, 'webdriver').get(), undefined);
+
+  // navigator.plugins should have at least one entry
+  const plugins = Object.getOwnPropertyDescriptor(ctx.navigator, 'plugins').get();
+  assert.ok(plugins.length > 0, 'plugins.length should be > 0');
+
+  // navigator.languages should be a non-empty array
+  const languages = Object.getOwnPropertyDescriptor(ctx.navigator, 'languages').get();
+  assert.ok(Array.isArray(languages) && languages.length > 0, 'languages should be non-empty array');
 });


### PR DESCRIPTION
## Summary
- Adds `--disable-blink-features=AutomationControlled` to Chromium launch args
- Injects stealth init script on every new page that patches `navigator.webdriver`, `navigator.plugins` (3 realistic Chrome entries), and `navigator.languages`
- Extracted to `stealth.js` module for testability
- Adds stealth test to `test.js` verifying the patches apply correctly in a VM sandbox

Fixes merx.com (and similar sites using headless browser fingerprinting) returning HTTP 403.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)