### PR TITLE
fix: resolve 5 bugs/improvements from PR #289 review

### DIFF
--- a/classifier/internal/classifier/classifier.go
+++ b/classifier/internal/classifier/classifier.go
@@ -272,6 +272,8 @@ func (c *Classifier) ClassifyBatch(ctx context.Context, rawItems []*domain.RawCo
 			infralogger.Int("failed", failedCount),
 			infralogger.Int("succeeded", len(rawItems)-failedCount),
 		)
+
+		return results, fmt.Errorf("classified %d/%d items successfully", len(rawItems)-failedCount, len(rawItems))
 	}
 
 	return results, nil

--- a/mcp-north-cloud/internal/mcp/handlers.go
+++ b/mcp-north-cloud/internal/mcp/handlers.go
@@ -234,7 +234,11 @@ func (s *Server) handleListCrawlJobs(ctx context.Context, id any, arguments json
 		Offset int    `json:"offset"`
 	}
 
-	_ = json.Unmarshal(arguments, &args) // Empty args is okay
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return s.errorResponse(id, InvalidParams, "invalid arguments: "+err.Error())
+		}
+	}
 
 	jobs, err := s.crawlerClient.ListJobs(ctx, args.Status)
 	if err != nil {
@@ -387,7 +391,11 @@ func (s *Server) handleListSources(ctx context.Context, id any, arguments json.R
 		Offset int `json:"offset"`
 	}
 
-	_ = json.Unmarshal(arguments, &args) // Empty args is okay
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return s.errorResponse(id, InvalidParams, "invalid arguments: "+err.Error())
+		}
+	}
 
 	sources, err := s.sourceClient.ListSources(ctx)
 	if err != nil {
@@ -571,7 +579,11 @@ func (s *Server) handleListCommunities(ctx context.Context, id any, arguments js
 		Offset int `json:"offset"`
 	}
 
-	_ = json.Unmarshal(arguments, &args) // Empty args is okay
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return s.errorResponse(id, InvalidParams, "invalid arguments: "+err.Error())
+		}
+	}
 
 	limit := max(args.Limit, 0)
 	if limit == 0 {
@@ -942,7 +954,11 @@ func (s *Server) handleListChannels(ctx context.Context, id any, arguments json.
 		ActiveOnly bool `json:"active_only"`
 	}
 
-	_ = json.Unmarshal(arguments, &args) // Empty args is okay
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return s.errorResponse(id, InvalidParams, "invalid arguments: "+err.Error())
+		}
+	}
 
 	channels, err := s.publisherClient.ListChannels(ctx)
 	if err != nil {
@@ -1017,7 +1033,11 @@ func (s *Server) handleGetPublishHistory(ctx context.Context, id any, arguments 
 		Offset      int    `json:"offset"`
 	}
 
-	_ = json.Unmarshal(arguments, &args) // Empty args is okay, use defaults
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return s.errorResponse(id, InvalidParams, "invalid arguments: "+err.Error())
+		}
+	}
 
 	// Apply limit/offset defaults and cap (Phase E: response size safeguard)
 	limit := max(args.Limit, 0)
@@ -1149,7 +1169,11 @@ func (s *Server) handleListIndexes(ctx context.Context, id any, arguments json.R
 		Offset int `json:"offset"`
 	}
 
-	_ = json.Unmarshal(arguments, &args) // Empty args is okay
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return s.errorResponse(id, InvalidParams, "invalid arguments: "+err.Error())
+		}
+	}
 
 	indexes, err := s.indexClient.ListIndices(ctx)
 	if err != nil {

--- a/source-manager/cmd/refresh-communities/main.go
+++ b/source-manager/cmd/refresh-communities/main.go
@@ -129,7 +129,11 @@ func printCIRNACResult(result *seeder.CIRNACResult, dryRun bool) {
 
 	fmt.Printf("\n[%s] CIRNAC Refresh Complete\n", mode)
 	fmt.Printf("  Total rows:  %d\n", result.Total)
-	fmt.Printf("  Upserted:    %d\n", result.Created)
+	if dryRun {
+		fmt.Printf("  Would create: %d\n", result.WouldCreate)
+	} else {
+		fmt.Printf("  Created:     %d\n", result.Created)
+	}
 	fmt.Printf("  Skipped:     %d\n", result.Skipped)
 	fmt.Printf("  Errors:      %d\n", result.Errors)
 }
@@ -145,7 +149,11 @@ func printStatscanResult(result *seeder.GeoNamesResult, province string, dryRun 
 		fmt.Printf("  Province:    %s\n", province)
 	}
 	fmt.Printf("  Processed:   %d\n", result.Total)
-	fmt.Printf("  Upserted:    %d\n", result.Created)
+	if dryRun {
+		fmt.Printf("  Would create: %d\n", result.WouldCreate)
+	} else {
+		fmt.Printf("  Created:     %d\n", result.Created)
+	}
 	fmt.Printf("  Skipped:     %d\n", result.Skipped)
 	fmt.Printf("  Errors:      %d\n", result.Errors)
 }

--- a/source-manager/cmd/seed-communities/main.go
+++ b/source-manager/cmd/seed-communities/main.go
@@ -83,7 +83,11 @@ func run(csvPath string, dryRun bool) error {
 
 	fmt.Printf("\n[%s] CIRNAC Seed Complete\n", mode)
 	fmt.Printf("  Total rows:  %d\n", result.Total)
-	fmt.Printf("  Created:     %d\n", result.Created)
+	if dryRun {
+		fmt.Printf("  Would create: %d\n", result.WouldCreate)
+	} else {
+		fmt.Printf("  Created:     %d\n", result.Created)
+	}
 	fmt.Printf("  Skipped:     %d\n", result.Skipped)
 	fmt.Printf("  Errors:      %d\n", result.Errors)
 

--- a/source-manager/cmd/seed-municipalities/main.go
+++ b/source-manager/cmd/seed-municipalities/main.go
@@ -82,7 +82,11 @@ func run(filePath, province string, dryRun bool) error {
 		fmt.Printf("  Province:    %s\n", province)
 	}
 	fmt.Printf("  Processed:   %d\n", result.Total)
-	fmt.Printf("  Created:     %d\n", result.Created)
+	if dryRun {
+		fmt.Printf("  Would create: %d\n", result.WouldCreate)
+	} else {
+		fmt.Printf("  Created:     %d\n", result.Created)
+	}
 	fmt.Printf("  Skipped:     %d\n", result.Skipped)
 	fmt.Printf("  Errors:      %d\n", result.Errors)
 

--- a/source-manager/internal/repository/source.go
+++ b/source-manager/internal/repository/source.go
@@ -324,15 +324,16 @@ func scanSourceRow(rows *sql.Rows) (*models.Source, error) {
 func buildListWhere(filter ListFilter) (whereClause string, args []any) {
 	var clauses []string
 	args = make([]any, 0)
-	pos := 1
+	// Derive placeholder position from args length to avoid manual pos tracking.
+	nextPos := func() int { return len(args) + 1 }
 
 	if filter.Search != "" {
+		pos := nextPos()
 		clauses = append(clauses, fmt.Sprintf("(name ILIKE $%d OR url ILIKE $%d)", pos, pos))
 		args = append(args, "%"+filter.Search+"%")
-		pos++
 	}
 	if filter.Enabled != nil {
-		clauses = append(clauses, fmt.Sprintf("enabled = $%d", pos))
+		clauses = append(clauses, fmt.Sprintf("enabled = $%d", nextPos()))
 		args = append(args, *filter.Enabled)
 	}
 

--- a/source-manager/internal/seeder/cirnac.go
+++ b/source-manager/internal/seeder/cirnac.go
@@ -27,11 +27,12 @@ const (
 
 // CIRNACResult holds the result of a CIRNAC seed operation.
 type CIRNACResult struct {
-	Total   int
-	Created int
-	Updated int
-	Skipped int
-	Errors  int
+	Total       int
+	Created     int
+	Updated     int
+	WouldCreate int
+	Skipped     int
+	Errors      int
 }
 
 // CIRNACSeeder imports CIRNAC open data CSV into the communities table.
@@ -122,7 +123,7 @@ func (s *CIRNACSeeder) processRecord(
 			infralogger.String("name", bandName),
 			infralogger.String("province", province),
 		)
-		result.Created++ // count as "would create" for dry-run summary
+		result.WouldCreate++
 		return
 	}
 

--- a/source-manager/internal/seeder/geonames.go
+++ b/source-manager/internal/seeder/geonames.go
@@ -57,10 +57,12 @@ var admin1ToProvince = map[string]string{
 
 // GeoNamesResult holds the result of a GeoNames seed operation.
 type GeoNamesResult struct {
-	Total   int
-	Created int
-	Skipped int
-	Errors  int
+	Total       int
+	Created     int
+	Updated     int
+	WouldCreate int
+	Skipped     int
+	Errors      int
 }
 
 // GeoNamesSeeder imports GeoNames populated places into the communities table.
@@ -151,7 +153,7 @@ func (s *GeoNamesSeeder) processGeoNamesRecord(
 			infralogger.String("province", province),
 			infralogger.String("type", community.CommunityType),
 		)
-		result.Created++
+		result.WouldCreate++
 		return
 	}
 
@@ -171,8 +173,6 @@ func (s *GeoNamesSeeder) processGeoNamesRecord(
 func (s *GeoNamesSeeder) buildGeoNamesCommunity(fields []string, province string) models.Community {
 	geoID := fields[gnColID]
 	name := fields[gnColName]
-	lat, _ := strconv.ParseFloat(fields[gnColLatitude], 64)
-	lng, _ := strconv.ParseFloat(fields[gnColLongitude], 64)
 	pop, _ := strconv.Atoi(fields[gnColPopulation])
 
 	communityType := InferCommunityType(pop)
@@ -184,11 +184,13 @@ func (s *GeoNamesSeeder) buildGeoNamesCommunity(fields []string, province string
 		CommunityType: communityType,
 		Province:      &province,
 		StatCanCSD:    &geoID,
-		Latitude:      &lat,
-		Longitude:     &lng,
 		DataSource:    dataSourceStatscan,
 		Enabled:       true,
 	}
+
+	lat, lng := parseGeoNamesCoords(fields)
+	c.Latitude = lat
+	c.Longitude = lng
 
 	if pop > 0 {
 		c.Population = &pop
@@ -196,6 +198,16 @@ func (s *GeoNamesSeeder) buildGeoNamesCommunity(fields []string, province string
 	}
 
 	return c
+}
+
+// parseGeoNamesCoords extracts lat/lng from GeoNames fields. Returns nil for invalid values.
+func parseGeoNamesCoords(fields []string) (latPtr, lngPtr *float64) {
+	latVal, latErr := strconv.ParseFloat(fields[gnColLatitude], 64)
+	lngVal, lngErr := strconv.ParseFloat(fields[gnColLongitude], 64)
+	if latErr != nil || lngErr != nil {
+		return nil, nil
+	}
+	return &latVal, &lngVal
 }
 
 // InferCommunityType returns a community type based on population.


### PR DESCRIPTION
## Summary

Fixes 5 issues discovered during PR #289 code review:

- **#290** (bug): `ClassifyBatch` now returns an error on partial failure instead of silently returning nil holes in the result slice
- **#291** (bug): GeoNames seeder uses `*float64` pointers for coordinates (matching CIRNAC pattern), preventing silent 0,0 storage on parse failure
- **#292** (improvement): MCP server pagination handlers now validate JSON before unmarshal — empty/nil args still use defaults, but malformed JSON returns an error
- **#293** (improvement): Seeder result structs add `WouldCreate` field for dry-run counts, separating them from actual `Created` upserts; CLI output updated accordingly
- **#294** (improvement): `buildListWhere` derives placeholder position from `len(args)+1` instead of fragile manual `pos` tracking

Closes #290, closes #291, closes #292, closes #293, closes #294

## Test plan

- [x] `task lint:classifier` — 0 issues
- [x] `task lint:source-manager` — 0 issues
- [x] `task lint:mcp-north-cloud` — 0 issues
- [x] `task test:classifier` — all pass
- [x] `task test:source-manager` — all pass
- [x] `task test:mcp-north-cloud` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)