### PR TITLE
feat(crawler): add page fetcher for leadership scraper (#273)

### DIFF
--- a/crawler/internal/scraper/pagefetcher.go
+++ b/crawler/internal/scraper/pagefetcher.go
@@ -1,0 +1,114 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/jonesrussell/north-cloud/crawler/internal/leadership"
+)
+
+const fetchTimeout = 30 * time.Second
+
+// PageFetcher downloads pages and extracts links and text.
+type PageFetcher struct {
+	httpClient *http.Client
+}
+
+// NewPageFetcher creates a new PageFetcher.
+func NewPageFetcher() *PageFetcher {
+	return &PageFetcher{
+		httpClient: &http.Client{Timeout: fetchTimeout},
+	}
+}
+
+// FetchLinks fetches a URL and returns all anchor links found on the page.
+func (f *PageFetcher) FetchLinks(ctx context.Context, pageURL string) ([]leadership.Link, error) {
+	doc, err := f.fetchDocument(ctx, pageURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var links []leadership.Link
+
+	doc.Find("a[href]").Each(func(_ int, s *goquery.Selection) {
+		href, exists := s.Attr("href")
+		if !exists || href == "" {
+			return
+		}
+
+		text := strings.TrimSpace(s.Text())
+		links = append(links, leadership.Link{
+			Href: href,
+			Text: text,
+		})
+	})
+
+	return links, nil
+}
+
+// FetchText fetches a URL and returns the visible text content of the page body.
+func (f *PageFetcher) FetchText(ctx context.Context, pageURL string) (string, error) {
+	doc, err := f.fetchDocument(ctx, pageURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Remove script and style elements before extracting text
+	doc.Find("script, style, noscript").Remove()
+
+	text := doc.Find("body").Text()
+
+	return NormalizeWhitespace(text), nil
+}
+
+// fetchDocument fetches a URL and parses it as an HTML document.
+func (f *PageFetcher) fetchDocument(ctx context.Context, pageURL string) (*goquery.Document, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request for %s: %w", pageURL, err)
+	}
+
+	resp, doErr := f.httpClient.Do(req)
+	if doErr != nil {
+		return nil, fmt.Errorf("fetch %s: %w", pageURL, doErr)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: status %d", pageURL, resp.StatusCode)
+	}
+
+	doc, parseErr := goquery.NewDocumentFromReader(resp.Body)
+	if parseErr != nil {
+		return nil, fmt.Errorf("parse HTML from %s: %w", pageURL, parseErr)
+	}
+
+	return doc, nil
+}
+
+// NormalizeWhitespace collapses runs of whitespace into single spaces and trims.
+func NormalizeWhitespace(s string) string {
+	var b strings.Builder
+
+	inSpace := false
+
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			if !inSpace {
+				b.WriteRune(' ')
+				inSpace = true
+			}
+
+			continue
+		}
+
+		inSpace = false
+		b.WriteRune(r)
+	}
+
+	return strings.TrimSpace(b.String())
+}

--- a/crawler/internal/scraper/pagefetcher_test.go
+++ b/crawler/internal/scraper/pagefetcher_test.go
@@ -1,0 +1,119 @@
+package scraper_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jonesrussell/north-cloud/crawler/internal/scraper"
+)
+
+const (
+	expectedLinkCount = 2
+)
+
+func TestPageFetcher_FetchLinks(t *testing.T) {
+	html := `<html><body>
+		<a href="/chief-and-council">Chief and Council</a>
+		<a href="/contact-us">Contact Us</a>
+		<a href="">Empty</a>
+		<a>No href</a>
+	</body></html>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(html))
+	}))
+	defer server.Close()
+
+	fetcher := scraper.NewPageFetcher()
+
+	links, err := fetcher.FetchLinks(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should get 2 links (empty href and no-href are skipped)
+	if len(links) != expectedLinkCount {
+		t.Fatalf("expected %d links, got %d", expectedLinkCount, len(links))
+	}
+
+	if links[0].Href != "/chief-and-council" {
+		t.Errorf("expected /chief-and-council, got %s", links[0].Href)
+	}
+
+	if links[0].Text != "Chief and Council" {
+		t.Errorf("expected 'Chief and Council', got %s", links[0].Text)
+	}
+
+	if links[1].Href != "/contact-us" {
+		t.Errorf("expected /contact-us, got %s", links[1].Href)
+	}
+}
+
+func TestPageFetcher_FetchText(t *testing.T) {
+	html := `<html><body>
+		<script>var x = 1;</script>
+		<style>body { color: red; }</style>
+		<h1>Chief and Council</h1>
+		<p>Chief John Smith leads the community.</p>
+		<p>Councillor Jane Doe serves on council.</p>
+	</body></html>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(html))
+	}))
+	defer server.Close()
+
+	fetcher := scraper.NewPageFetcher()
+
+	text, err := fetcher.FetchText(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should not contain script or style content
+	if strings.Contains(text, "var x = 1") {
+		t.Error("text should not contain script content")
+	}
+
+	if strings.Contains(text, "color: red") {
+		t.Error("text should not contain style content")
+	}
+
+	// Should contain actual content
+	if !strings.Contains(text, "Chief and Council") {
+		t.Error("text should contain 'Chief and Council'")
+	}
+
+	if !strings.Contains(text, "Chief John Smith") {
+		t.Error("text should contain 'Chief John Smith'")
+	}
+}
+
+func TestPageFetcher_FetchLinks_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	fetcher := scraper.NewPageFetcher()
+
+	_, err := fetcher.FetchLinks(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
+func TestNormalizeWhitespace(t *testing.T) {
+	input := "  hello   \n\n  world  \t  foo  "
+	expected := "hello world foo"
+
+	result := scraper.NormalizeWhitespace(input)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `crawler/internal/scraper/pagefetcher.go` — downloads pages, extracts links and visible text
- Uses goquery (already vendored via colly) for HTML parsing
- Strips script/style elements before text extraction
- 4 unit tests using `httptest.NewServer`

**Part 4 of 5** for #273 (Leadership & Contact Page Scraper)

## Test plan
- [x] `GOWORK=off go build ./...` passes
- [x] `GOWORK=off go test ./internal/scraper/...` — 4 tests pass
- [x] `GOWORK=off golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>