### PR TITLE
fix(docker): expose source-manager port 8050 to localhost

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -141,6 +141,8 @@ services:
   source-manager:
     <<: *prod-defaults
     image: docker.io/jonesrussell/source-manager:latest
+    ports:
+      - "127.0.0.1:8050:8050"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- Adds `ports: - "127.0.0.1:8050:8050"` to source-manager service in `docker-compose.prod.yml`
- Binds to localhost only — accessible for MCP tools and CLI debugging but not externally exposed

Closes #305

## Test plan
- [ ] Deploy to production and verify `curl http://localhost:8050/health` works from host
- [ ] Verify port is not accessible externally (`curl http://<public-ip>:8050` should fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)