### PR TITLE
fix(mcp): remove stale nolint:dupl directives in publisher and crawler clients

### DIFF
--- a/mcp-north-cloud/internal/client/crawler.go
+++ b/mcp-north-cloud/internal/client/crawler.go
@@ -364,8 +364,6 @@ func (c *CrawlerClient) GetJobStats(ctx context.Context, jobID string) (*JobStat
 }
 
 // GetSchedulerMetrics gets scheduler-wide metrics
-//
-//nolint:dupl // Similar HTTP client pattern across different services is acceptable
 func (c *CrawlerClient) GetSchedulerMetrics(ctx context.Context) (*SchedulerMetrics, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/scheduler/metrics", c.baseURL)
 

--- a/mcp-north-cloud/internal/client/publisher.go
+++ b/mcp-north-cloud/internal/client/publisher.go
@@ -126,8 +126,6 @@ func (c *PublisherClient) GetPublishHistory(ctx context.Context, channelName str
 }
 
 // GetStats gets publisher statistics
-//
-//nolint:dupl // Similar HTTP client pattern across different services is acceptable
 func (c *PublisherClient) GetStats(ctx context.Context) (*PublisherStats, error) {
 	// Use period=all to get all-time totals
 	endpoint := fmt.Sprintf("%s/api/v1/stats/overview?period=all", c.baseURL)


### PR DESCRIPTION
## Summary

- Removes unused `//nolint:dupl` from `GetStats` in `publisher.go` — the function is now structurally unique after the intermediate struct was added in #337
- Removes unused `//nolint:dupl` from `GetSchedulerMetrics` in `crawler.go` — was already unused before #337

Both were flagged by `nolintlint` in CI after #337 merged. This unblocks the main branch CI failure.

## Test plan

- [ ] CI lint passes on this branch
- [ ] Main branch CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)