### PR TITLE
fix(classifier): add meta object fields to raw_content ES mapping

### DIFF
--- a/classifier/internal/elasticsearch/mappings/mappings.go
+++ b/classifier/internal/elasticsearch/mappings/mappings.go
@@ -50,8 +50,14 @@ func ToJSON(mapping any) (string, error) {
 
 // Field represents an Elasticsearch field mapping
 type Field struct {
-	Type     string `json:"type,omitempty"`
-	Analyzer string `json:"analyzer,omitempty"`
-	Format   string `json:"format,omitempty"`
-	Index    *bool  `json:"index,omitempty"` // Pointer to allow explicit false
+	Type     string           `json:"type,omitempty"`
+	Analyzer string           `json:"analyzer,omitempty"`
+	Format   string           `json:"format,omitempty"`
+	Index    *bool            `json:"index,omitempty"` // Pointer to allow explicit false
+	Fields   map[string]Field `json:"fields,omitempty"`
+}
+
+// ObjectField represents an Elasticsearch object field with nested properties
+type ObjectField struct {
+	Properties map[string]Field `json:"properties"`
 }

--- a/classifier/internal/elasticsearch/mappings/raw_content.go
+++ b/classifier/internal/elasticsearch/mappings/raw_content.go
@@ -50,6 +50,37 @@ type RawContentProperties struct {
 
 	// Quick metrics
 	WordCount Field `json:"word_count"`
+
+	// Meta object written by the crawler
+	Meta ObjectField `json:"meta"`
+}
+
+// newMetaObjectField returns the ObjectField definition for the crawler-written meta object.
+func newMetaObjectField() ObjectField {
+	textWithKeyword := func(typ string) Field {
+		return Field{
+			Type:   typ,
+			Fields: map[string]Field{"keyword": {Type: "keyword"}},
+		}
+	}
+	dateField := Field{Type: "date", Format: "strict_date_optional_time||epoch_millis"}
+
+	return ObjectField{
+		Properties: map[string]Field{
+			"page_type":             textWithKeyword("text"),
+			"detected_content_type": textWithKeyword("text"),
+			"indigenous_region":     textWithKeyword("text"),
+			"article_opinion":       {Type: "keyword"},
+			"article_content_tier":  {Type: "keyword"},
+			"twitter_card":          {Type: "keyword"},
+			"twitter_site":          {Type: "keyword"},
+			"og_image_width":        {Type: "keyword"},
+			"og_image_height":       {Type: "keyword"},
+			"og_site_name":          {Type: "keyword"},
+			"created_at":            dateField,
+			"updated_at":            dateField,
+		},
+	}
 }
 
 // NewRawContentMapping creates a new raw content mapping with default settings
@@ -129,6 +160,7 @@ func NewRawContentMapping() *RawContentMapping {
 				WordCount: Field{
 					Type: "integer",
 				},
+				Meta: newMetaObjectField(),
 			},
 		},
 	}

--- a/classifier/internal/elasticsearch/mappings/raw_content_test.go
+++ b/classifier/internal/elasticsearch/mappings/raw_content_test.go
@@ -1,0 +1,133 @@
+package mappings_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jonesrussell/north-cloud/classifier/internal/elasticsearch/mappings"
+)
+
+func TestNewRawContentMapping_MetaFieldExists(t *testing.T) {
+	t.Helper()
+
+	m := mappings.NewRawContentMapping()
+
+	if m.Mappings.Properties.Meta.Properties == nil {
+		t.Fatal("expected Meta.Properties to be non-nil")
+	}
+}
+
+func TestNewRawContentMapping_MetaPageType(t *testing.T) {
+	t.Helper()
+
+	m := mappings.NewRawContentMapping()
+
+	f, ok := m.Mappings.Properties.Meta.Properties["page_type"]
+	if !ok {
+		t.Fatal("expected 'page_type' in Meta.Properties")
+	}
+
+	if f.Type != "text" {
+		t.Errorf("expected page_type type 'text', got %q", f.Type)
+	}
+
+	kw, hasKeyword := f.Fields["keyword"]
+	if !hasKeyword {
+		t.Fatal("expected 'keyword' sub-field on page_type")
+	}
+
+	if kw.Type != "keyword" {
+		t.Errorf("expected keyword sub-field type 'keyword', got %q", kw.Type)
+	}
+}
+
+func TestNewRawContentMapping_MetaAllFields(t *testing.T) {
+	t.Helper()
+
+	m := mappings.NewRawContentMapping()
+	props := m.Mappings.Properties.Meta.Properties
+
+	expectedKeywordFields := []string{
+		"article_opinion",
+		"article_content_tier",
+		"twitter_card",
+		"twitter_site",
+		"og_image_width",
+		"og_image_height",
+		"og_site_name",
+	}
+
+	for _, name := range expectedKeywordFields {
+		f, ok := props[name]
+		if !ok {
+			t.Errorf("expected meta field %q to exist", name)
+			continue
+		}
+
+		if f.Type != "keyword" {
+			t.Errorf("expected meta field %q to have type 'keyword', got %q", name, f.Type)
+		}
+	}
+
+	expectedDateFields := []string{"created_at", "updated_at"}
+	for _, name := range expectedDateFields {
+		f, ok := props[name]
+		if !ok {
+			t.Errorf("expected meta field %q to exist", name)
+			continue
+		}
+
+		if f.Type != "date" {
+			t.Errorf("expected meta field %q to have type 'date', got %q", name, f.Type)
+		}
+	}
+
+	expectedTextFields := []string{"page_type", "detected_content_type", "indigenous_region"}
+	for _, name := range expectedTextFields {
+		f, ok := props[name]
+		if !ok {
+			t.Errorf("expected meta field %q to exist", name)
+			continue
+		}
+
+		if f.Type != "text" {
+			t.Errorf("expected meta field %q to have type 'text', got %q", name, f.Type)
+		}
+	}
+}
+
+func TestNewRawContentMapping_GetJSONContainsMeta(t *testing.T) {
+	t.Helper()
+
+	m := mappings.NewRawContentMapping()
+
+	jsonStr, err := m.GetJSON()
+	if err != nil {
+		t.Fatalf("GetJSON() returned error: %v", err)
+	}
+
+	if !strings.Contains(jsonStr, `"meta"`) {
+		t.Error("expected GetJSON() output to contain \"meta\"")
+	}
+
+	if !strings.Contains(jsonStr, `"page_type"`) {
+		t.Error("expected GetJSON() output to contain \"page_type\"")
+	}
+}
+
+func TestNewRawContentMapping_GetJSONValid(t *testing.T) {
+	t.Helper()
+
+	m := mappings.NewRawContentMapping()
+
+	jsonStr, err := m.GetJSON()
+	if err != nil {
+		t.Fatalf("GetJSON() returned error: %v", err)
+	}
+
+	var result map[string]any
+	if unmarshalErr := json.Unmarshal([]byte(jsonStr), &result); unmarshalErr != nil {
+		t.Fatalf("GetJSON() produced invalid JSON: %v", unmarshalErr)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `meta` object with all 12 fields to the canonical `raw_content` Elasticsearch index mapping. This prevents `strict_dynamic_mapping_exception` on indices with `dynamic: strict`.

## Root Cause

The crawler writes `meta["page_type"]` (and 11 other meta fields) at indexing time, but the canonical mapping had no `meta` object defined. Strict-mode indices rejected any document containing `meta.*` fields, causing 198 crawler errors in production on 2026-03-14. A production hot-fix applied `page_type` only via `PUT *_raw_content/_mapping`.

## Changes

- `mappings.go` — added `Fields map[string]Field` to `Field` struct; added `ObjectField` type for nested ES objects
- `raw_content.go` — added `Meta ObjectField` to `RawContentProperties`; extracted `newMetaObjectField()` helper; populated all 12 meta fields
- `raw_content_test.go` — new test file covering meta field existence, type assertions, and `GetJSON()` output

## Meta Fields Added

| Field | ES Type |
|-------|---------|
| `page_type` | text + keyword subfield |
| `detected_content_type` | text + keyword subfield |
| `indigenous_region` | text + keyword subfield |
| `article_opinion` | keyword |
| `article_content_tier` | keyword |
| `twitter_card` | keyword |
| `twitter_site` | keyword |
| `og_image_width` | keyword |
| `og_image_height` | keyword |
| `og_site_name` | keyword |
| `created_at` | date |
| `updated_at` | date |

## Test Plan

- [x] Unit tests added in `raw_content_test.go`
- [x] `golangci-lint run` passes
- [x] `go test ./internal/elasticsearch/...` passes

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)