### PR TITLE
chore(governance): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS
+# Each line is a file pattern followed by one or more owners.
+# Order matters — the last matching pattern wins.
+
+# Global owner — covers everything not matched below
+* @jonesrussell
+
+# Service-specific owners
+/crawler/          @jonesrussell
+/classifier/       @jonesrussell
+/publisher/        @jonesrussell
+/search/           @jonesrussell
+/index-manager/    @jonesrussell
+/source-manager/   @jonesrussell
+/dashboard/        @jonesrussell
+/auth/             @jonesrussell
+/ai-observer/      @jonesrussell
+/infrastructure/   @jonesrussell
+/mcp-north-cloud/  @jonesrussell
+
+# CI/CD and governance
+/.github/          @jonesrussell
+/docs/             @jonesrussell


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` assigning `@jonesrussell` as code owner for all services, CI/CD, and documentation.

## Motivation

Branch protection has been enabled on `main` (requires Vulnerability Check + GitGuardian). CODEOWNERS is required for proper PR review enforcement and audit trail.

## Changes

- `.github/CODEOWNERS` — global `*` owner + per-service owners for all 11 services

## Test Plan

- [x] YAML/file syntax valid
- [x] No code changes — CI will pass Vulnerability Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)