### PR TITLE
feat(docker): unified ML sidecar Dockerfile with MODULE_NAME build args

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -23,6 +23,16 @@ x-service-defaults: &service-defaults
   networks:
     - north-cloud-network
 
+x-ml-sidecar: &ml-sidecar-defaults
+  restart: unless-stopped
+  networks:
+    - north-cloud-network
+  deploy:
+    resources:
+      limits:
+        cpus: "0.5"
+        memory: 512M
+
 # ============================================================
 # Services
 # ============================================================
@@ -347,116 +357,87 @@ services:
   # ------------------------------------------------------------
 
   crime-ml:
-    <<: *service-defaults
+    <<: *ml-sidecar-defaults
     build:
-      context: ./ml-sidecars/crime-ml
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/Dockerfile.ml-sidecar
+      args:
+        MODULE_NAME: crime
     image: docker.io/jonesrussell/crime-ml:latest
-    deploy:
-      resources:
-        limits:
-          cpus: "0.5"
-          memory: 512M
-    environment:
-      MODEL_PATH: /app/models
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8076/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
+    ports:
+      - "${CRIME_ML_PORT:-8076}:8080"
 
   # ------------------------------------------------------------
   # Mining ML Classifier
   # ------------------------------------------------------------
 
   mining-ml:
-    <<: *service-defaults
+    <<: *ml-sidecar-defaults
     build:
-      context: ./ml-sidecars/mining-ml
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/Dockerfile.ml-sidecar
+      args:
+        MODULE_NAME: mining
     image: docker.io/jonesrussell/mining-ml:latest
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 512M
-    environment:
-      MODEL_PATH: /app/models
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8077/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
+          memory: 1G
+    ports:
+      - "${MINING_ML_PORT:-8077}:8080"
 
   # ------------------------------------------------------------
   # Coforge ML Classifier
   # ------------------------------------------------------------
 
   coforge-ml:
-    <<: *service-defaults
+    <<: *ml-sidecar-defaults
     build:
-      context: ./ml-sidecars/coforge-ml
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/Dockerfile.ml-sidecar
+      args:
+        MODULE_NAME: coforge
     image: docker.io/jonesrussell/coforge-ml:latest
-    deploy:
-      resources:
-        limits:
-          cpus: "0.5"
-          memory: 512M
-    environment:
-      MODEL_PATH: /app/models
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8078/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
+    ports:
+      - "${COFORGE_ML_PORT:-8078}:8080"
 
   # ------------------------------------------------------------
   # Entertainment ML Classifier
   # ------------------------------------------------------------
 
   entertainment-ml:
-    <<: *service-defaults
+    <<: *ml-sidecar-defaults
     build:
-      context: ./ml-sidecars/entertainment-ml
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/Dockerfile.ml-sidecar
+      args:
+        MODULE_NAME: entertainment
     image: docker.io/jonesrussell/entertainment-ml:latest
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 512M
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8079/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
+          memory: 256M
+    ports:
+      - "${ENTERTAINMENT_ML_PORT:-8079}:8080"
 
   # ------------------------------------------------------------
   # Indigenous ML Classifier
   # ------------------------------------------------------------
 
   indigenous-ml:
-    <<: *service-defaults
+    <<: *ml-sidecar-defaults
     build:
-      context: ./ml-sidecars/indigenous-ml
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/Dockerfile.ml-sidecar
+      args:
+        MODULE_NAME: indigenous
     image: docker.io/jonesrussell/indigenous-ml:latest
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 512M
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
+          memory: 256M
+    ports:
+      - "${INDIGENOUS_ML_PORT:-8080}:8080"
 
   # ------------------------------------------------------------
   # HTTP Replay Proxy (nc-http-proxy)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -285,12 +285,12 @@ services:
       CONCURRENT_WORKERS: "${CLASSIFIER_CONCURRENCY:-5}"
       PPROF_PORT: 6060
       MINING_ENABLED: "${MINING_ENABLED:-true}"
-      MINING_ML_SERVICE_URL: "http://mining-ml:8077"
+      MINING_ML_SERVICE_URL: "http://mining-ml:8080"
       PIPELINE_URL: "${PIPELINE_URL:-}"
       COFORGE_ENABLED: "${COFORGE_ENABLED:-true}"
-      COFORGE_ML_SERVICE_URL: "http://coforge-ml:8078"
+      COFORGE_ML_SERVICE_URL: "http://coforge-ml:8080"
       ENTERTAINMENT_ENABLED: "${ENTERTAINMENT_ENABLED:-true}"
-      ENTERTAINMENT_ML_SERVICE_URL: "http://entertainment-ml:8079"
+      ENTERTAINMENT_ML_SERVICE_URL: "http://entertainment-ml:8080"
       INDIGENOUS_ENABLED: "${INDIGENOUS_ENABLED:-false}"
       INDIGENOUS_ML_SERVICE_URL: "http://indigenous-ml:8080"
       RECIPE_ENABLED: "${RECIPE_ENABLED:-true}"
@@ -576,8 +576,9 @@ services:
   crime-ml:
     profiles:
       - ml
-    ports:
-      - "${CRIME_ML_PORT:-8076}:8076"
+    volumes:
+      - ./ml-modules/crime:/opt/module
+      - ./ml-framework:/opt/ml-framework
 
   # ------------------------------------------------------------
   # Mining ML Classifier (Dev) — gated behind `ml` profile
@@ -585,8 +586,9 @@ services:
   mining-ml:
     profiles:
       - ml
-    ports:
-      - "${MINING_ML_PORT:-8077}:8077"
+    volumes:
+      - ./ml-modules/mining:/opt/module
+      - ./ml-framework:/opt/ml-framework
 
   # ------------------------------------------------------------
   # Coforge ML Classifier (Dev) — gated behind `ml` profile
@@ -594,8 +596,9 @@ services:
   coforge-ml:
     profiles:
       - ml
-    ports:
-      - "${COFORGE_ML_PORT:-8078}:8078"
+    volumes:
+      - ./ml-modules/coforge:/opt/module
+      - ./ml-framework:/opt/ml-framework
 
   # ------------------------------------------------------------
   # Entertainment ML Classifier (Dev) — gated behind `ml` profile
@@ -603,8 +606,9 @@ services:
   entertainment-ml:
     profiles:
       - ml
-    ports:
-      - "${ENTERTAINMENT_ML_PORT:-8079}:8079"
+    volumes:
+      - ./ml-modules/entertainment:/opt/module
+      - ./ml-framework:/opt/ml-framework
 
   # ------------------------------------------------------------
   # Indigenous ML Classifier (Dev) — gated behind `ml` profile
@@ -612,8 +616,9 @@ services:
   indigenous-ml:
     profiles:
       - ml
-    ports:
-      - "${INDIGENOUS_ML_PORT:-8080}:8080"
+    volumes:
+      - ./ml-modules/indigenous:/opt/module
+      - ./ml-framework:/opt/ml-framework
 
   # ------------------------------------------------------------
   # HTTP Replay Proxy (Dev)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -257,13 +257,13 @@ services:
       APP_ENV: production
       CLASSIFIER_PORT: 8070
       CRIME_ENABLED: "true"
-      CRIME_ML_SERVICE_URL: http://crime-ml:8076
+      CRIME_ML_SERVICE_URL: http://crime-ml:8080
       MINING_ENABLED: "true"
-      MINING_ML_SERVICE_URL: http://mining-ml:8077
+      MINING_ML_SERVICE_URL: http://mining-ml:8080
       COFORGE_ENABLED: "true"
-      COFORGE_ML_SERVICE_URL: http://coforge-ml:8078
+      COFORGE_ML_SERVICE_URL: http://coforge-ml:8080
       ENTERTAINMENT_ENABLED: "true"
-      ENTERTAINMENT_ML_SERVICE_URL: http://entertainment-ml:8079
+      ENTERTAINMENT_ML_SERVICE_URL: http://entertainment-ml:8080
       INDIGENOUS_ENABLED: "${INDIGENOUS_ENABLED:-false}"
       INDIGENOUS_ML_SERVICE_URL: http://indigenous-ml:8080
       RFP_ENABLED: "true"
@@ -275,6 +275,13 @@ services:
       timeout: 10s
       retries: 3
       start_period: 25s
+
+  # ------------------------------------------------------------
+  # Crime ML Classifier (Prod)
+  # ------------------------------------------------------------
+  crime-ml:
+    <<: *prod-defaults
+    image: docker.io/jonesrussell/crime-ml:latest
 
   # ------------------------------------------------------------
   # Mining ML Classifier (Prod)


### PR DESCRIPTION
## Summary
- Replace individual per-sidecar Dockerfiles (`ml-sidecars/*/Dockerfile`) with the shared `docker/Dockerfile.ml-sidecar` using `MODULE_NAME` build args in all three compose files
- Add `x-ml-sidecar` YAML anchor in `docker-compose.base.yml` for DRY shared config (restart policy, network, resource limits)
- Update all classifier ML service URLs from per-sidecar ports (8076-8080) to standardized port 8080
- Add dev volume mounts for `ml-modules/` and `ml-framework/` for hot-reload during development
- Add missing `crime-ml` prod override (was absent from `docker-compose.prod.yml`)

## Test plan
- [x] `docker compose -f docker-compose.base.yml -f docker-compose.dev.yml config --quiet` passes
- [x] `docker compose -f docker-compose.base.yml -f docker-compose.prod.yml config --quiet` passes
- [x] No remaining `ml-sidecars/` references in compose files
- [ ] `task docker:dev:up:ml` starts all ML sidecars using shared Dockerfile
- [ ] Classifier connects to ML sidecars on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)