### PR TITLE
fix(deploy): deployment reliability improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,13 +167,30 @@ jobs:
           ssh-keyscan -H -p "${DEPLOY_SSH_PORT}" "${DEPLOY_HOST}" >> ~/.ssh/known_hosts 2>/dev/null
           chmod 600 ~/.ssh/known_hosts
 
+      - name: Validate migration prefixes
+        run: |
+          echo "Checking for duplicate migration prefixes..."
+          FOUND_DUPES=false
+          for dir in */migrations/; do
+            [ -d "$dir" ] || continue
+            dupes=$(ls "$dir" 2>/dev/null | grep -E '\.sql$' | sed 's/_.*//' | sort | uniq -d)
+            if [ -n "$dupes" ]; then
+              echo "::error::Duplicate migration prefixes in $dir: $dupes"
+              FOUND_DUPES=true
+            fi
+          done
+          if [ "$FOUND_DUPES" = true ]; then
+            echo "::error::Deploy aborted — fix duplicate migration prefixes before deploying."
+            exit 1
+          fi
+          echo "No duplicate migration prefixes found."
+
       - name: Sync files to server
         env:
           SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
-          # Create a tarball of all deployment files (faster than multiple scp)
           tar -czf /tmp/deploy-files.tar.gz \
             docker-compose.base.yml \
             docker-compose.prod.yml \
@@ -184,17 +201,18 @@ jobs:
             --exclude='*.txt' \
             2>/dev/null || true
 
-          # Transfer and extract in one operation
           scp -P "${SSH_PORT}" /tmp/deploy-files.tar.gz "${DEPLOY_USER}@${DEPLOY_HOST}:/tmp/"
 
           ssh -p "${SSH_PORT}" "${DEPLOY_USER}@${DEPLOY_HOST}" '
             cd /opt/north-cloud
-            # Remove stale migration files before extracting (tar only adds, never deletes)
+            # Remove stale files before extracting (tar only adds, never deletes).
+            # Migrations: prevents duplicate prefix crashes in golang-migrate.
+            # Infrastructure configs: prevents renamed/removed configs from persisting.
             find . -maxdepth 2 -path "*/migrations/*.sql" -delete 2>/dev/null || true
+            find ./infrastructure -type f \( -name "*.yml" -o -name "*.yaml" -o -name "*.conf" -o -name "*.alloy" -o -name "*.json" \) -delete 2>/dev/null || true
             tar -xzf /tmp/deploy-files.tar.gz
             rm /tmp/deploy-files.tar.gz
             chmod +x scripts/deploy.sh 2>/dev/null || chmod +x deploy.sh 2>/dev/null || true
-            # Move deploy.sh to expected location if it was in scripts/
             [ -f scripts/deploy.sh ] && mv scripts/deploy.sh deploy.sh
           '
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,14 @@ See `ARCHITECTURE.md` for the full bootstrap pattern reference.
 ### Production Deployment
 
 - Production (`/opt/north-cloud`) is **NOT a git repo** — do not use `git pull`
-- CI/CD (GitHub Actions) syncs files via rsync and runs `deploy.sh`
+- CI/CD (GitHub Actions) syncs files via tar archive and runs `deploy.sh`
 - To deploy manually: push to main → CI runs tests → deploy workflow triggers automatically
 - **Nginx uses `--force-recreate`** — volume-mounted config changes aren't detected by `up -d`
 - **Force deploy**: `gh workflow run deploy.yml -f force_rebuild_all=true` to rebuild all services
-- **Rsync does NOT delete renamed/removed files** — old files persist on server. If renaming migrations or removing files, manually delete old versions via SSH (#387)
+- **Stale file cleanup**: Deploy pre-deletes `*/migrations/*.sql` and `infrastructure/` configs before extracting tar. Renamed/removed files in these paths are cleaned automatically.
+- **Migration prefix validation**: Deploy fails fast if duplicate migration prefixes are detected (prevents golang-migrate crashes).
+- **Health checks + auto-rollback**: `deploy.sh` snapshots images before deploy, runs health checks after restart, and auto-rolls-back failed services.
+- **Runbook**: See `docs/RUNBOOK.md` for rollback procedures and troubleshooting.
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,197 @@
+# North Cloud Production Runbook
+
+## Deployment
+
+### How deploys work
+
+1. Push to `main` triggers CI (`.github/workflows/test.yml`)
+2. On CI success, `.github/workflows/deploy.yml` runs automatically
+3. Deploy detects changed services, builds Docker images, pushes to Docker Hub
+4. Syncs compose files, infrastructure configs, and migrations to production via tar
+5. Runs `deploy.sh` on the server: pulls images, runs migrations, restarts services
+6. Health checks run automatically — failed services are rolled back
+
+### Manual deploy
+
+```bash
+# Deploy all services
+gh workflow run deploy.yml
+
+# Force rebuild all services (ignores change detection)
+gh workflow run deploy.yml -f force_rebuild_all=true
+
+# Deploy specific services only
+gh workflow run deploy.yml -f services="crawler,classifier"
+```
+
+### Monitor a deploy
+
+```bash
+gh run watch
+gh run list --workflow=deploy.yml
+gh run view <run-id> --log
+```
+
+---
+
+## Rollback Procedures
+
+### Automatic rollback (built into deploy.sh)
+
+`deploy.sh` automatically:
+1. Snapshots current Docker image IDs before pulling new ones
+2. Runs health checks after restart (Step 4)
+3. If any health check fails, re-tags the old image and restarts the service
+4. Reports rollback success or failure
+
+No manual intervention needed for service-level failures.
+
+### Manual rollback — failed service
+
+If automatic rollback failed or you need to force a specific version:
+
+```bash
+ssh jones@northcloud.one
+cd /opt/north-cloud
+
+# Check which services are unhealthy
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml ps
+
+# Restart a specific service with the previous image
+# (Docker keeps the previous image locally after pull)
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml \
+  up -d --force-recreate <service-name>
+
+# Check logs
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml \
+  logs -f <service-name> --tail=50
+```
+
+### Manual rollback — bad migration
+
+If a migration broke the database:
+
+```bash
+ssh jones@northcloud.one
+cd /opt/north-cloud
+
+# Source environment for DB credentials
+source .env
+
+# Check migration state (example: crawler)
+docker run --rm --network north-cloud_north-cloud-network \
+  migrate/migrate:latest \
+  -path /dev/null \
+  -database "postgres://${POSTGRES_CRAWLER_USER}:${POSTGRES_CRAWLER_PASSWORD}@postgres-crawler:5432/${POSTGRES_CRAWLER_DB:-crawler}?sslmode=disable" \
+  version
+
+# Run the down migration (rolls back one step)
+docker run --rm --network north-cloud_north-cloud-network \
+  -v /opt/north-cloud/crawler/migrations:/migrations \
+  migrate/migrate:latest \
+  -path /migrations \
+  -database "postgres://${POSTGRES_CRAWLER_USER}:${POSTGRES_CRAWLER_PASSWORD}@postgres-crawler:5432/${POSTGRES_CRAWLER_DB:-crawler}?sslmode=disable" \
+  down 1
+
+# If migration is in dirty state, force to previous version
+docker run --rm --network north-cloud_north-cloud-network \
+  -v /opt/north-cloud/crawler/migrations:/migrations \
+  migrate/migrate:latest \
+  -path /migrations \
+  -database "postgres://..." \
+  force <previous-version-number>
+```
+
+### Manual rollback — full deploy revert
+
+To redeploy the last known good state:
+
+```bash
+# Find the last successful deploy commit
+git log --oneline deployed
+
+# Trigger a deploy from that commit
+gh workflow run deploy.yml -f force_rebuild_all=true
+# (This rebuilds from current main — if main is broken, cherry-pick the fix)
+```
+
+---
+
+## Troubleshooting
+
+### Service won't start
+
+```bash
+ssh jones@northcloud.one
+cd /opt/north-cloud
+
+# Check container status
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml ps
+
+# Check logs (last 100 lines)
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml \
+  logs <service-name> --tail=100
+
+# Check if port is already in use
+netstat -tulpn | grep <port>
+
+# Force recreate
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml \
+  up -d --force-recreate <service-name>
+```
+
+### Database connection failures
+
+```bash
+# Test DB connectivity
+docker exec -it north-cloud-postgres-<service> psql -U postgres -d <database> -c "SELECT 1"
+
+# Check if DB container is running
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml ps postgres-<service>
+
+# Restart DB (warning: brief downtime)
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml restart postgres-<service>
+```
+
+### Migration duplicate prefix crash
+
+```bash
+# Identify duplicates
+for dir in */migrations/; do
+  dupes=$(ls "$dir" | grep '\.sql$' | sed 's/_.*//' | sort | uniq -d)
+  [ -n "$dupes" ] && echo "$dir: $dupes"
+done
+
+# Remove the stale file (the old renamed one)
+rm <service>/migrations/<old-prefix>_<old-name>.{up,down}.sql
+
+# Re-run migrations
+bash deploy.sh
+```
+
+### Stale files after deploy
+
+The deploy pipeline cleans migrations and infrastructure configs before extracting.
+If other file types persist after rename/removal, manually delete on production:
+
+```bash
+ssh jones@northcloud.one
+rm /opt/north-cloud/<path-to-stale-file>
+```
+
+### Nginx config not reloading
+
+Nginx uses `--force-recreate` in deploy.sh (Step 3.5). If config still stale:
+
+```bash
+ssh jones@northcloud.one
+cd /opt/north-cloud
+docker compose -f docker-compose.base.yml -f docker-compose.prod.yml \
+  up -d --force-recreate nginx
+```
+
+Caddy (TLS termination) is a host process, not Docker:
+
+```bash
+sudo systemctl reload caddy
+```


### PR DESCRIPTION
## Summary
- Add pre-deploy migration prefix duplicate check — fails fast before syncing to production, preventing golang-migrate crashes
- Extend stale file cleanup to `infrastructure/` configs (yml, yaml, conf, alloy, json) alongside existing migration cleanup
- Create `docs/RUNBOOK.md` documenting rollback procedures, manual deploy, migration recovery, and troubleshooting
- Update CLAUDE.md to reflect current deploy pipeline capabilities
- Health check smoke tests already exist in `deploy.sh` Step 4 with automatic rollback — no additional changes needed

## Issues
- Closes #387 — rsync should delete renamed/removed files from production
- Closes #408 — add migration prefix duplicate check before rsync
- Closes #409 — add health check smoke test after service restart (already implemented in deploy.sh)
- Closes #410 — document rollback procedure for failed deploys

## Test plan
- [ ] Verify migration prefix check catches duplicates: create a duplicate prefix in a test branch, confirm deploy.yml step fails
- [ ] Verify infrastructure/ cleanup: rename an infra config, deploy, confirm old file is gone
- [ ] Verify existing health check + rollback still works (deploy.sh Step 4)
- [ ] Review RUNBOOK.md for accuracy against production setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)