### PR TITLE
feat(ci): per-service image tag tracking via manifest file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,6 +216,36 @@ jobs:
             [ -f scripts/deploy.sh ] && mv scripts/deploy.sh deploy.sh
           '
 
+      - name: Update image tag manifest
+        env:
+          SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          SHORT_SHA=$(echo "${DEPLOY_SHA}" | cut -c1-7)
+          TAG="sha-${SHORT_SHA}"
+
+          # Update image-tags.env on the server for changed services only.
+          # Each service gets its own _TAG variable; unchanged services keep
+          # their previous tag. Compose reads these via ${SERVICE_TAG:-latest}.
+          ssh -p "${SSH_PORT}" "${DEPLOY_USER}@${DEPLOY_HOST}" "
+            cd /opt/north-cloud
+            touch image-tags.env
+
+            for svc in ${CHANGED_SERVICES//,/ }; do
+              # Convert service name to env var: lowercase-hyphen → UPPER_SNAKE_TAG
+              VAR=\$(echo \"\${svc}\" | tr '[:lower:]-' '[:upper:]_')_TAG
+              # Remove old entry and append new one
+              grep -v \"^\${VAR}=\" image-tags.env > image-tags.env.tmp || true
+              mv image-tags.env.tmp image-tags.env
+              echo \"\${VAR}=${TAG}\" >> image-tags.env
+            done
+
+            echo 'Updated image-tags.env:'
+            cat image-tags.env
+          "
+
       - name: Deploy services
         env:
           SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
@@ -230,10 +260,14 @@ jobs:
             export INFRA_CHANGED='${INFRA_CHANGED}'
             export MIGRATIONS_CHANGED='${MIGRATIONS_CHANGED}'
 
-            # IMAGE_TAG defaults to 'latest' via \${IMAGE_TAG:-latest} in compose.
-            # SHA tags (sha-abc1234) are pushed to Docker Hub for rollback but
-            # not used automatically — only changed services get the new SHA tag,
-            # so setting IMAGE_TAG globally would break unchanged services.
+            # Source per-service image tags (e.g. CRAWLER_TAG=sha-abc1234)
+            # Unchanged services keep their previous tag; missing vars
+            # fall back to 'latest' via \${SERVICE_TAG:-latest} in compose.
+            if [ -f image-tags.env ]; then
+              set -a
+              . ./image-tags.env
+              set +a
+            fi
 
             # Run optimized deploy
             bash deploy.sh

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@ services:
   # ------------------------------------------------------------
   crawler:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/crawler:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/crawler:${CRAWLER_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -106,7 +106,7 @@ services:
   # ------------------------------------------------------------
   ai-observer:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/ai-observer:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/ai-observer:${AI_OBSERVER_TAG:-latest}
     restart: on-failure
 
   # ------------------------------------------------------------
@@ -140,7 +140,7 @@ services:
   # ------------------------------------------------------------
   source-manager:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/source-manager:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/source-manager:${SOURCE_MANAGER_TAG:-latest}
     ports:
       - "127.0.0.1:8050:8050"
     deploy:
@@ -179,7 +179,7 @@ services:
   # ------------------------------------------------------------
   publisher:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/publisher:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/publisher:${PUBLISHER_TAG:-latest}
     command: ["/app/publisher", "both"]
     deploy:
       resources:
@@ -220,7 +220,7 @@ services:
   # ------------------------------------------------------------
   classifier:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/classifier:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/classifier:${CLASSIFIER_TAG:-latest}
     command: ["./classifier", "both"]
     deploy:
       resources:
@@ -281,7 +281,7 @@ services:
   # ------------------------------------------------------------
   crime-ml:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/crime-ml:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/crime-ml:${CRIME_ML_TAG:-latest}
     ports: []  # No external ports in prod — classifier reaches via Docker network
     # Healthcheck defined in Dockerfile.ml-sidecar (uses python urllib)
 
@@ -290,7 +290,7 @@ services:
   # ------------------------------------------------------------
   mining-ml:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/mining-ml:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/mining-ml:${MINING_ML_TAG:-latest}
     ports: []
 
   # ------------------------------------------------------------
@@ -298,7 +298,7 @@ services:
   # ------------------------------------------------------------
   coforge-ml:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/coforge-ml:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/coforge-ml:${COFORGE_ML_TAG:-latest}
     ports: []
 
   # ------------------------------------------------------------
@@ -306,7 +306,7 @@ services:
   # ------------------------------------------------------------
   entertainment-ml:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/entertainment-ml:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/entertainment-ml:${ENTERTAINMENT_ML_TAG:-latest}
     ports: []
 
   # ------------------------------------------------------------
@@ -314,7 +314,7 @@ services:
   # ------------------------------------------------------------
   indigenous-ml:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/indigenous-ml:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/indigenous-ml:${INDIGENOUS_ML_TAG:-latest}
     ports: []
 
   # ------------------------------------------------------------
@@ -322,7 +322,7 @@ services:
   # ------------------------------------------------------------
   pipeline:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/pipeline:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/pipeline:${PIPELINE_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -354,7 +354,7 @@ services:
   # ------------------------------------------------------------
   index-manager:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/index-manager:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/index-manager:${INDEX_MANAGER_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -388,7 +388,7 @@ services:
   # ------------------------------------------------------------
   search-service:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/search-service:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/search-service:${SEARCH_SERVICE_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -419,7 +419,7 @@ services:
   # ------------------------------------------------------------
   search-frontend:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/search-frontend:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/search-frontend:${SEARCH_FRONTEND_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -437,7 +437,7 @@ services:
   # ------------------------------------------------------------
   nc-http-proxy:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/nc-http-proxy:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/nc-http-proxy:${NC_HTTP_PROXY_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -467,7 +467,7 @@ services:
   # ------------------------------------------------------------
   auth:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/auth:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/auth:${AUTH_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -493,7 +493,7 @@ services:
   # ------------------------------------------------------------
   mcp-north-cloud:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/mcp-north-cloud:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/mcp-north-cloud:${MCP_NORTH_CLOUD_TAG:-latest}
     # MCP server is stdio-based: connect via `docker exec -i <container> /app/mcp-north-cloud`
     # The container idles so the binary is available for on-demand connections.
     command: ["sleep", "infinity"]
@@ -532,7 +532,7 @@ services:
   # ------------------------------------------------------------
   playwright-renderer:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/playwright-renderer:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/playwright-renderer:${PLAYWRIGHT_RENDERER_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -550,7 +550,7 @@ services:
   # ------------------------------------------------------------
   dashboard:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/dashboard:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/dashboard:${DASHBOARD_TAG:-latest}
     deploy:
       resources:
         limits:
@@ -735,7 +735,7 @@ services:
 
   rfp-ingestor:
     <<: *prod-defaults
-    image: docker.io/jonesrussell/rfp-ingestor:${IMAGE_TAG:-latest}
+    image: docker.io/jonesrussell/rfp-ingestor:${RFP_INGESTOR_TAG:-latest}
     deploy:
       resources:
         limits:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,6 +30,16 @@ COMPOSE_CMD="docker compose -f docker-compose.base.yml -f docker-compose.prod.ym
 SNAPSHOT_FILE="/tmp/nc-deploy-snapshot-$$"
 ROLLBACK_ATTEMPTED=false
 
+# Source per-service image tags if available (e.g. CRAWLER_TAG=sha-abc1234).
+# These are written by the CI workflow for changed services; unchanged
+# services fall back to 'latest' via ${SERVICE_TAG:-latest} in compose.
+if [ -f "$DEPLOY_DIR/image-tags.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$DEPLOY_DIR/image-tags.env"
+  set +a
+fi
+
 # Change to deployment directory
 cd "$DEPLOY_DIR" || {
   echo -e "${RED}ERROR: Failed to change to deployment directory: $DEPLOY_DIR${NC}" >&2


### PR DESCRIPTION
## Summary

Implements per-service image tag tracking using a server-side manifest file (`image-tags.env`). Each service gets its own tag variable instead of a shared `IMAGE_TAG`.

### Architecture Decision

Evaluated three approaches:
- **A. Tag manifest file** (chosen) — per-service vars in `image-tags.env`, updated by CI for changed services only
- B. Docker aliasing — mutable `:deployed` tag, loses immutability
- C. Force rebuild all — wastes CI time for unchanged services

### How It Works

1. CI builds changed services, pushes `latest` + `sha-<short>` tags
2. New "Update image tag manifest" step writes `SERVICE_TAG=sha-abc1234` to `image-tags.env` on the server for each changed service
3. Deploy step sources `image-tags.env` before running `docker compose up`
4. Each service in `docker-compose.prod.yml` uses `${SERVICE_TAG:-latest}`
5. Unchanged services keep their previous tag; missing vars fall back to `latest`

### Rollback

```bash
# Edit the tag for the service to roll back
vim /opt/north-cloud/image-tags.env  # change CRAWLER_TAG=sha-abc1234 to sha-prev123
bash deploy.sh
```

### Verification

```bash
# Set one service, verify others fall back
CRAWLER_TAG=sha-abc1234 docker compose ... config | grep crawler
# → docker.io/jonesrussell/crawler:sha-abc1234

# Unset services use latest
docker compose ... config | grep classifier
# → docker.io/jonesrussell/classifier:latest
```

Closes #456

## Test plan

- [x] Compose interpolation verified locally (per-service tag + fallback)
- [x] Spec drift check passes
- [ ] Deploy to production and verify `image-tags.env` is written
- [ ] Verify services start with correct per-service tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)