### PR TITLE
fix(deploy): correct classifier health check port

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -209,7 +209,7 @@ rollback_services() {
       auth)          check_health "auth" "/health" "8040" 10 || rollback_healthy=false ;;
       crawler)       check_health "crawler" "/health" "8080" 20 || rollback_healthy=false ;;
       source-manager) check_health "source-manager" "/health" "8050" 10 || rollback_healthy=false ;;
-      classifier)    check_health "classifier" "/health" "8070" 10 || rollback_healthy=false ;;
+      classifier)    check_health "classifier" "/health" "8071" 10 || rollback_healthy=false ;;
       publisher)     check_health "publisher" "/health" "8070" 10 || rollback_healthy=false ;;
       index-manager) check_health "index-manager" "/health" "8090" 10 || rollback_healthy=false ;;
       pipeline)      check_health "pipeline" "/health" "8075" 10 || rollback_healthy=false ;;
@@ -554,7 +554,7 @@ for svc in $SERVICES_TO_CHECK; do
       check_health "source-manager" "/health" "8050" 10 || { FAILED_CHECKS=$((FAILED_CHECKS + 1)); FAILED_SERVICES="$FAILED_SERVICES $svc"; }
       ;;
     classifier)
-      check_health "classifier" "/health" "8070" 10 || { FAILED_CHECKS=$((FAILED_CHECKS + 1)); FAILED_SERVICES="$FAILED_SERVICES $svc"; }
+      check_health "classifier" "/health" "8071" 10 || { FAILED_CHECKS=$((FAILED_CHECKS + 1)); FAILED_SERVICES="$FAILED_SERVICES $svc"; }
       ;;
     publisher)
       check_health "publisher" "/health" "8070" 10 || { FAILED_CHECKS=$((FAILED_CHECKS + 1)); FAILED_SERVICES="$FAILED_SERVICES $svc"; }

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Regression test: validate deploy.sh health check ports match expected service ports.
+# Run: bash scripts/deploy_test.sh
+# This prevents port drift like #458 (classifier checked on publisher's port).
+
+set -euo pipefail
+
+DEPLOY_SCRIPT="$(dirname "$0")/deploy.sh"
+PASS=0
+FAIL=0
+
+# Expected service→port mapping (source of truth: CLAUDE.md / docker-compose)
+declare -A EXPECTED_PORTS=(
+  [auth]=8040
+  [crawler]=8080
+  [source-manager]=8050
+  [classifier]=8071
+  [publisher]=8070
+  [index-manager]=8090
+  [pipeline]=8075
+  [search-service]=8090
+)
+
+check_port() {
+  local service="$1"
+  local expected="$2"
+
+  # Find all check_health lines for this service and extract ports
+  local ports
+  ports=$(grep -oP "check_health\s+\"${service}\"\s+\"/health\"\s+\"\K[0-9]+" "$DEPLOY_SCRIPT" || true)
+
+  if [ -z "$ports" ]; then
+    echo "SKIP: $service — no health check found in deploy.sh"
+    return
+  fi
+
+  while IFS= read -r port; do
+    if [ "$port" = "$expected" ]; then
+      echo "PASS: $service → port $port"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $service → port $port (expected $expected)"
+      FAIL=$((FAIL + 1))
+    fi
+  done <<< "$ports"
+}
+
+echo "=== deploy.sh health check port validation ==="
+echo ""
+
+for service in "${!EXPECTED_PORTS[@]}"; do
+  check_port "$service" "${EXPECTED_PORTS[$service]}"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "ERROR: Port mismatches detected — update deploy.sh or EXPECTED_PORTS"
+  exit 1
+fi
+
+echo "All health check ports match expected values."


### PR DESCRIPTION
## Summary
- Fixed classifier health check port from 8070 (publisher) to 8071 (classifier) in `scripts/deploy.sh`
- Both rollback health check (line 212) and post-deploy check (line 557) were affected
- Added `scripts/deploy_test.sh` regression test that validates all health check ports against expected values

## Impact
Auto-rollback and post-deploy health checks for the classifier service were silently broken — checking publisher's port instead of classifier's. A classifier outage would not trigger rollback.

## Test plan
- [x] `bash scripts/deploy_test.sh` — 16/16 port checks pass
- [ ] Deploy to staging and verify classifier health check triggers correctly

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)