### PR TITLE
fix: bump coforge-ml memory limit from 512M to 1G

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -399,6 +399,10 @@ services:
       args:
         MODULE_NAME: coforge
     image: docker.io/jonesrussell/coforge-ml:latest
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     ports:
       - "${COFORGE_ML_PORT:-8078}:8000"
 


### PR DESCRIPTION
## Summary

- Increase coforge-ml container memory limit from 512M (default) to 1G (matches mining-ml)
- During the Mar 22 incident, coforge-ml returned repeated 500 errors causing classifier batch slowdowns and publisher cursor lag (#529)
- Current usage is 49MB/512MB — this adds burst headroom, not fixing an active OOM
- Circuit breaker already handles the failure fast-path (`mlclient/breaker.go`)

## Test plan

- [x] Server has 4.3GB available memory — headroom is sufficient
- [ ] Deploy and verify coforge-ml container shows new 1G limit via `docker stats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)