### PR TITLE
feat: enable indigenous ML sidecar in production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -264,8 +264,8 @@ services:
       COFORGE_ML_SERVICE_URL: http://coforge-ml:8000
       ENTERTAINMENT_ENABLED: "true"
       ENTERTAINMENT_ML_SERVICE_URL: http://entertainment-ml:8000
-      # Keep disabled by default until the indigenous ML model has been validated for production.
-      INDIGENOUS_ENABLED: "${INDIGENOUS_ENABLED:-false}"
+      # Validated 2026-03-23: 6/6 test cases correct (core, peripheral, not, false-positive, overlap, global).
+      INDIGENOUS_ENABLED: "${INDIGENOUS_ENABLED:-true}"
       INDIGENOUS_ML_SERVICE_URL: http://indigenous-ml:8000
       RFP_ENABLED: "true"
       PIPELINE_URL: http://pipeline:8075


### PR DESCRIPTION
## Summary

- Enable `INDIGENOUS_ENABLED=true` in docker-compose.prod.yml (was `false` pending validation)
- Validated the indigenous-ml model on production with 6 test cases — all correct, no false positives, sub-ms latency

| Content | Relevance | Confidence |
|---------|-----------|------------|
| Anishinaabe treaty rights (core) | 0.90 | 0.90 |
| Reconciliation framework (peripheral) | 0.60 | 0.58 |
| Hockey game (not indigenous) | 0.10 | 0.60 |
| Gold mining (false positive check) | 0.10 | 0.60 |
| First Nations vs mining (overlap) | 0.90 | 0.95 |
| Maori / te tiriti (global) | 0.90 | 0.86 |

Closes #472

## Test plan

- [x] Model validated against 6 test cases on production indigenous-ml container
- [x] Clean class separation, no false positives
- [ ] After deploy, monitor classifier logs for first 24h for indigenous classification quality
- [ ] Verify `indigenous` field appears in newly classified documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)