### PR TITLE
chore(docker): add default 1G memory limit to ml-sidecar-defaults anchor

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -31,7 +31,7 @@ x-ml-sidecar: &ml-sidecar-defaults
     resources:
       limits:
         cpus: "0.5"
-        memory: 512M
+        memory: 1G
 
 # ============================================================
 # Services
@@ -380,10 +380,6 @@ services:
       args:
         MODULE_NAME: mining
     image: docker.io/jonesrussell/mining-ml:latest
-    deploy:
-      resources:
-        limits:
-          memory: 1G
     ports:
       - "${MINING_ML_PORT:-8077}:8000"
 
@@ -399,10 +395,6 @@ services:
       args:
         MODULE_NAME: coforge
     image: docker.io/jonesrussell/coforge-ml:latest
-    deploy:
-      resources:
-        limits:
-          memory: 1G
     ports:
       - "${COFORGE_ML_PORT:-8078}:8000"
 


### PR DESCRIPTION
## Summary
- Raises `x-ml-sidecar` anchor memory limit to 1G
- Removes redundant explicit overrides from mining-ml and coforge-ml
- entertainment-ml and indigenous-ml keep their 256M overrides

Closes #551

## Test plan
- [x] `docker compose config` validates correctly
- [x] Memory limits verified per-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)