### PR TITLE
test(source-manager): add test coverage for critical packages

### DIFF
--- a/source-manager/internal/handlers/source_extra_test.go
+++ b/source-manager/internal/handlers/source_extra_test.go
@@ -1,0 +1,428 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/handlers"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/repository"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockSourceHandlerExtra(t *testing.T) (*handlers.SourceHandler, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	repo := repository.NewSourceRepository(db, testhelpers.NewTestLogger())
+	handler := handlers.NewSourceHandler(repo, testhelpers.NewTestLogger(), nil)
+
+	cleanup := func() {
+		mock.ExpectClose()
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("db.Close: %v", closeErr)
+		}
+	}
+
+	return handler, mock, cleanup
+}
+
+func sourceListCols() []string {
+	return []string{
+		"id", "name", "url", "rate_limit", "max_depth",
+		"time", "selectors", "enabled",
+		"feed_url", "sitemap_url", "ingestion_mode", "feed_poll_interval_minutes",
+		"feed_disabled_at", "feed_disable_reason",
+		"allow_source_discovery", "identity_key", "extraction_profile", "template_hint",
+		"render_mode", "type", "indigenous_region",
+		"disabled_at", "disable_reason",
+		"created_at", "updated_at",
+	}
+}
+
+func addSourceRowExtra(rows *sqlmock.Rows, id, name string) {
+	now := time.Now()
+	rows.AddRow(
+		id, name, "https://example.com", "1s", 2,
+		[]byte(`["09:00"]`),
+		[]byte(`{"article":{"title":"h1"},"list":{},"page":{}}`),
+		true,
+		nil, nil, "", 0,
+		nil, nil,
+		false, nil, nil, nil,
+		"static", "news", nil,
+		nil, nil,
+		now, now,
+	)
+}
+
+func TestSourceHandler_List_WithSearchParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources", handler.List)
+
+	rows := sqlmock.NewRows(sourceListCols())
+	addSourceRowExtra(rows, "id-1", "CBC News")
+
+	mock.ExpectQuery("SELECT id, name, url").
+		WithArgs("%cbc%", 100, 0).
+		WillReturnRows(rows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs("%cbc%").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources?search=cbc", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.InDelta(t, 1, resp["total"], 0.001)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_List_WithPagination(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources", handler.List)
+
+	rows := sqlmock.NewRows(sourceListCols())
+	addSourceRowExtra(rows, "id-2", "Source Page 2")
+
+	mock.ExpectQuery("SELECT id, name, url").
+		WithArgs(10, 10).
+		WillReturnRows(rows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(25))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources?limit=10&page=2", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.InDelta(t, 25, resp["total"], 0.001)
+	assert.InDelta(t, 2, resp["page"], 0.001)
+	assert.InDelta(t, 10, resp["per_page"], 0.001)
+	assert.InDelta(t, 3, resp["total_pages"], 0.001)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_List_WithEnabledFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources", handler.List)
+
+	rows := sqlmock.NewRows(sourceListCols())
+	addSourceRowExtra(rows, "id-1", "Enabled Source")
+
+	mock.ExpectQuery("SELECT id, name, url").
+		WithArgs(true, 100, 0).
+		WillReturnRows(rows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(true).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources?enabled=true", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_List_DBError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := newClosedDBSourceHandler(t)
+
+	router.GET("/api/v1/sources", handler.List)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestSourceHandler_GetCities_DBError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := newClosedDBSourceHandler(t)
+
+	router.GET("/api/v1/cities", handler.GetCities)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cities", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestSourceHandler_Update_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.PUT("/api/v1/sources/:id", handler.Update)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs(
+			"upd-id",
+			"Updated Source", "https://updated.com", "5s", 3,
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			true,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// GetByID after update
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("upd-id").
+		WillReturnRows(
+			sqlmock.NewRows(sourceListCols()).AddRow(
+				"upd-id", "Updated Source", "https://updated.com", "5s", 3,
+				[]byte(`["09:00"]`),
+				[]byte(`{"article":{"title":"h1"},"list":{},"page":{}}`),
+				true,
+				nil, nil, "crawl", 0,
+				nil, nil,
+				false, nil, nil, nil,
+				"static", "news", nil,
+				nil, nil,
+				now, now,
+			),
+		)
+
+	body := `{"name":"Updated Source","url":"https://updated.com","rate_limit":"5","max_depth":3,"enabled":true}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sources/upd-id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_DisableFeed_MissingBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/disable-feed", handler.DisableFeed)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/disable-feed",
+		http.NoBody,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_DisableFeed_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/disable-feed", handler.DisableFeed)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("550e8400-e29b-41d4-a716-446655440000", "not_found").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"reason":"not_found"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/disable-feed",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_EnableFeed_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/enable-feed", handler.EnableFeed)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("550e8400-e29b-41d4-a716-446655440000").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/enable-feed",
+		http.NoBody,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_DisableSource_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/disable", handler.DisableSource)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("550e8400-e29b-41d4-a716-446655440000", "maintenance").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"reason":"maintenance"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/disable",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_EnableSource_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/enable", handler.EnableSource)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("550e8400-e29b-41d4-a716-446655440000").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/enable",
+		http.NoBody,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_DisableFeed_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/disable-feed", handler.DisableFeed)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("550e8400-e29b-41d4-a716-446655440000", "not_found").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	body := `{"reason":"not_found"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/disable-feed",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_EnableFeed_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/enable-feed", handler.EnableFeed)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("550e8400-e29b-41d4-a716-446655440000").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/550e8400-e29b-41d4-a716-446655440000/enable-feed",
+		http.NoBody,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_GetByIdentityKey_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandlerExtra(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources/by-identity-key", handler.GetByIdentityKey)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("no-match").
+		WillReturnRows(sqlmock.NewRows(sourceListCols()))
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/sources/by-identity-key?identity_key=no-match",
+		http.NoBody,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/source-manager/internal/handlers/source_test.go
+++ b/source-manager/internal/handlers/source_test.go
@@ -1,0 +1,568 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/handlers"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/repository"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockSourceHandler(t *testing.T) (*handlers.SourceHandler, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	repo := repository.NewSourceRepository(db, testhelpers.NewTestLogger())
+	handler := handlers.NewSourceHandler(repo, testhelpers.NewTestLogger(), nil)
+
+	cleanup := func() {
+		mock.ExpectClose()
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("db.Close: %v", closeErr)
+		}
+	}
+
+	return handler, mock, cleanup
+}
+
+func TestSourceHandler_Create_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources", handler.Create)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_Create_InvalidSourceType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources", handler.Create)
+
+	body := `{"name":"Test","url":"https://example.com","type":"invalid_type"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid source type")
+}
+
+func TestSourceHandler_Create_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources", handler.Create)
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO sources")).
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			"Test Source", "https://example.com", "10s", 0,
+			sqlmock.AnyArg(), // time
+			sqlmock.AnyArg(), // selectors
+			false,
+			sqlmock.AnyArg(), // feed_url
+			sqlmock.AnyArg(), // sitemap_url
+			sqlmock.AnyArg(), // ingestion_mode
+			sqlmock.AnyArg(), // feed_poll_interval_minutes
+			sqlmock.AnyArg(), // allow_source_discovery
+			sqlmock.AnyArg(), // identity_key
+			sqlmock.AnyArg(), // extraction_profile
+			sqlmock.AnyArg(), // template_hint
+			sqlmock.AnyArg(), // render_mode
+			sqlmock.AnyArg(), // type
+			sqlmock.AnyArg(), // indigenous_region
+			sqlmock.AnyArg(), // created_at
+			sqlmock.AnyArg(), // updated_at
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	body := `{"name":"Test Source","url":"https://example.com","rate_limit":"10"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp models.Source
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.ID)
+	assert.Equal(t, "Test Source", resp.Name)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_GetByID_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources/:id", handler.GetByID)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("not-found-id").
+		WillReturnRows(sqlmock.NewRows(nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/not-found-id", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_GetByID_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources/:id", handler.GetByID)
+
+	now := time.Now()
+	selectorsJSON := []byte(`{"article":{"title":"h1"},"list":{},"page":{}}`)
+	timeJSON := []byte(`["09:00"]`)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("src-123").
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "name", "url", "rate_limit", "max_depth",
+				"time", "selectors", "enabled",
+				"feed_url", "sitemap_url", "ingestion_mode", "feed_poll_interval_minutes",
+				"feed_disabled_at", "feed_disable_reason",
+				"allow_source_discovery", "identity_key", "extraction_profile", "template_hint",
+				"render_mode", "type", "indigenous_region",
+				"disabled_at", "disable_reason",
+				"created_at", "updated_at",
+			}).AddRow(
+				"src-123", "My Source", "https://example.com", "5s", 3,
+				timeJSON, selectorsJSON, true,
+				nil, nil, "crawl", 0,
+				nil, nil,
+				false, nil, nil, nil,
+				"static", "news", nil,
+				nil, nil,
+				now, now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/src-123", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp models.Source
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "src-123", resp.ID)
+	assert.Equal(t, "My Source", resp.Name)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_Delete_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.DELETE("/api/v1/sources/:id", handler.Delete)
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM sources WHERE id = $1")).
+		WithArgs("del-id").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sources/del-id", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_Delete_Error(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.DELETE("/api/v1/sources/:id", handler.Delete)
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM sources WHERE id = $1")).
+		WithArgs("fail-id").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sources/fail-id", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_Update_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.PUT("/api/v1/sources/:id", handler.Update)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sources/some-id", strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_Update_InvalidSourceType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.PUT("/api/v1/sources/:id", handler.Update)
+
+	body := `{"name":"Test","url":"https://example.com","type":"bad_type"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sources/some-id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_GetByIdentityKey_MissingParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources/by-identity-key", handler.GetByIdentityKey)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/by-identity-key", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "identity_key")
+}
+
+func TestSourceHandler_GetCities_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.GET("/api/v1/cities", handler.GetCities)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT name as source_name")).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"source_name"}).
+				AddRow("Sudbury").
+				AddRow("Timmins"),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cities", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	cities, ok := resp["cities"].([]any)
+	require.True(t, ok)
+	assert.Len(t, cities, 2)
+	assert.InDelta(t, 2, resp["count"], 0.001)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceHandler_FetchMetadata_MissingURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/fetch-metadata", handler.FetchMetadata)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/fetch-metadata", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_TestCrawl_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/test-crawl", handler.TestCrawl)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/test-crawl", strings.NewReader(`invalid`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_TestCrawl_MissingURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/test-crawl", handler.TestCrawl)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/test-crawl", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_DisableFeed_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/disable-feed", handler.DisableFeed)
+
+	body := `{"reason":"test reason"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/not-a-uuid/disable-feed", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid source ID")
+}
+
+func TestSourceHandler_EnableFeed_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/enable-feed", handler.EnableFeed)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/not-a-uuid/enable-feed", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_DisableSource_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/disable", handler.DisableSource)
+
+	body := `{"reason":"maintenance"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/bad-id/disable", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_EnableSource_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/:id/enable", handler.EnableSource)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/bad-id/enable", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_BatchCreate_EmptySources(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/batch", handler.BatchCreate)
+
+	body := `{"sources":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "empty")
+}
+
+func TestSourceHandler_BatchCreate_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/batch", handler.BatchCreate)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/batch", strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_ImportExcel_NoFile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/import-excel", handler.ImportExcel)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/import-excel", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_ImportIndigenous_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, _, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.POST("/api/v1/sources/import-indigenous", handler.ImportIndigenous)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sources/import-indigenous",
+		strings.NewReader(`not-json`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSourceHandler_ListIndigenous_DBError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Use closed DB for error path
+	handler := newClosedDBSourceHandler(t)
+	router.GET("/api/v1/sources/indigenous", handler.ListIndigenous)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/indigenous", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// newClosedDBSourceHandler creates a SourceHandler backed by a closed DB for error-path testing.
+func newClosedDBSourceHandler(t *testing.T) *handlers.SourceHandler {
+	t.Helper()
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	db.Close()
+
+	repo := repository.NewSourceRepository(db, testhelpers.NewTestLogger())
+	return handlers.NewSourceHandler(repo, testhelpers.NewTestLogger(), nil)
+}
+
+func TestSourceHandler_List_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler, mock, cleanup := newMockSourceHandler(t)
+	defer cleanup()
+
+	router.GET("/api/v1/sources", handler.List)
+
+	now := time.Now()
+	selectorsJSON := []byte(`{"article":{},"list":{},"page":{}}`)
+	timeJSON := []byte(`[]`)
+
+	mock.ExpectQuery("SELECT id, name, url").
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "name", "url", "rate_limit", "max_depth",
+				"time", "selectors", "enabled",
+				"feed_url", "sitemap_url", "ingestion_mode", "feed_poll_interval_minutes",
+				"feed_disabled_at", "feed_disable_reason",
+				"allow_source_discovery", "identity_key", "extraction_profile", "template_hint",
+				"render_mode", "type", "indigenous_region",
+				"disabled_at", "disable_reason",
+				"created_at", "updated_at",
+			}).AddRow(
+				"id-1", "Source 1", "https://example.com", "1s", 2,
+				timeJSON, selectorsJSON, true,
+				nil, nil, "", 0,
+				nil, nil,
+				false, nil, nil, nil,
+				"", "news", nil,
+				nil, nil,
+				now, now,
+			),
+		)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM sources WHERE 1=1")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources?limit=10&page=1", http.NoBody)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.InDelta(t, 1, resp["total"], 0.001)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/source-manager/internal/repository/band_office_mock_test.go
+++ b/source-manager/internal/repository/band_office_mock_test.go
@@ -1,0 +1,150 @@
+//nolint:testpackage // Testing with sqlmock requires same-package access
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockBandOfficeRepo(t *testing.T) (*BandOfficeRepository, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	repo := NewBandOfficeRepository(db, newTestLogger(t))
+	cleanup := func() {
+		mock.ExpectClose()
+		db.Close()
+	}
+
+	return repo, mock, cleanup
+}
+
+func bandOfficeCols() []string {
+	return []string{
+		"id", "community_id", "data_source", "verified", "created_at", "updated_at",
+		"address_line1", "address_line2", "city", "province", "postal_code",
+		"phone", "fax", "email", "toll_free", "office_hours", "source_url", "verified_at",
+		"verification_confidence", "verification_issues",
+	}
+}
+
+func TestBandOfficeRepository_Create_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockBandOfficeRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	bo := &models.BandOffice{
+		CommunityID: "c-1",
+		DataSource:  "manual",
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO band_offices")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.Create(ctx, bo)
+	require.NoError(t, err)
+	assert.NotEmpty(t, bo.ID)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBandOfficeRepository_GetByCommunity_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockBandOfficeRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + bandOfficeColumns)).
+		WithArgs("c-1").
+		WillReturnRows(
+			sqlmock.NewRows(bandOfficeCols()).AddRow(
+				"bo-1", "c-1", "manual", false, now, now,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil, nil, nil, nil,
+				nil, nil,
+			),
+		)
+
+	bo, err := repo.GetByCommunity(ctx, "c-1")
+	require.NoError(t, err)
+	require.NotNil(t, bo)
+	assert.Equal(t, "c-1", bo.CommunityID)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBandOfficeRepository_GetByCommunity_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockBandOfficeRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + bandOfficeColumns)).
+		WithArgs("missing").
+		WillReturnRows(sqlmock.NewRows(bandOfficeCols()))
+
+	bo, err := repo.GetByCommunity(ctx, "missing")
+	require.NoError(t, err)
+	assert.Nil(t, bo)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBandOfficeRepository_Delete_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockBandOfficeRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM band_offices")).
+		WithArgs("c-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.DeleteByCommunity(ctx, "c-1")
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBandOfficeRepository_Delete_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockBandOfficeRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM band_offices")).
+		WithArgs("missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.DeleteByCommunity(ctx, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBandOfficeRepository_Update_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockBandOfficeRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	bo := &models.BandOffice{ID: "missing", CommunityID: "c-1"}
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE band_offices")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.Update(ctx, bo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/source-manager/internal/repository/community_mock_test.go
+++ b/source-manager/internal/repository/community_mock_test.go
@@ -1,0 +1,375 @@
+//nolint:testpackage // Testing with sqlmock requires same-package access
+package repository
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockCommunityRepo(t *testing.T) (*CommunityRepository, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	repo := NewCommunityRepository(db, newTestLogger(t))
+	cleanup := func() {
+		mock.ExpectClose()
+		db.Close()
+	}
+
+	return repo, mock, cleanup
+}
+
+func communityColumns() []string {
+	return []string{
+		"id", "name", "slug", "community_type", "province", "region",
+		"inac_id", "statcan_csd", "osm_relation_id", "wikidata_qid", "latitude", "longitude",
+		"nation", "treaty", "language_group", "reserve_name", "population", "population_year",
+		"website", "feed_url", "data_source", "source_id", "enabled", "created_at", "updated_at",
+	}
+}
+
+func TestCommunityRepository_Create_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	c := &models.Community{
+		Name:          "Sudbury",
+		Slug:          "sudbury",
+		CommunityType: "city",
+		DataSource:    "manual",
+		Enabled:       true,
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO communities")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.Create(ctx, c)
+	require.NoError(t, err)
+	assert.NotEmpty(t, c.ID)
+	assert.False(t, c.CreatedAt.IsZero())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_GetByID_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, slug")).
+		WithArgs("c-1").
+		WillReturnRows(
+			sqlmock.NewRows(communityColumns()).AddRow(
+				"c-1", "Sudbury", "sudbury", "city", "ON", nil,
+				nil, nil, nil, nil, 46.49, -81.0,
+				nil, nil, nil, nil, nil, nil,
+				nil, nil, "manual", nil, true, now, now,
+			),
+		)
+
+	c, err := repo.GetByID(ctx, "c-1")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "Sudbury", c.Name)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_GetByID_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, slug")).
+		WithArgs("missing").
+		WillReturnRows(sqlmock.NewRows(communityColumns()))
+
+	c, err := repo.GetByID(ctx, "missing")
+	require.NoError(t, err)
+	assert.Nil(t, c)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_Delete_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM communities WHERE id = $1")).
+		WithArgs("del-c").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.Delete(ctx, "del-c")
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_Delete_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM communities WHERE id = $1")).
+		WithArgs("missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.Delete(ctx, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_Count_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM communities")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(15))
+
+	count, err := repo.Count(ctx, models.CommunityFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 15, count)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_ListRegions_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COALESCE(province")).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"province", "region", "count"}).
+				AddRow("ON", "", 5).
+				AddRow("BC", "", 3),
+		)
+
+	regions, err := repo.ListRegions(ctx)
+	require.NoError(t, err)
+	require.Len(t, regions, 2)
+	assert.Equal(t, "ON", regions[0].Province)
+	assert.Equal(t, 5, regions[0].Count)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_SetSourceLink_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET source_id")).
+		WithArgs("c-1", "src-1", "https://example.com").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.SetSourceLink(ctx, "c-1", "src-1", "https://example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_SetSourceLink_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET source_id")).
+		WithArgs("missing", "src-1", "https://example.com").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.SetSourceLink(ctx, "missing", "src-1", "https://example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_BulkUpdateWebsite_Empty(t *testing.T) {
+	repo, _, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	updated, err := repo.BulkUpdateWebsiteByInacID(ctx, []WebsiteUpdate{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, updated)
+}
+
+func TestCommunityRepository_BulkUpdateWebsite_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET website")).
+		WithArgs("https://band1.ca", "100").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET website")).
+		WithArgs("https://band2.ca", "200").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	updated, err := repo.BulkUpdateWebsiteByInacID(ctx, []WebsiteUpdate{
+		{InacID: "100", Website: "https://band1.ca"},
+		{InacID: "200", Website: "https://band2.ca"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, updated)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_UpsertByInacID_NilInacID(t *testing.T) {
+	repo, _, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	c := &models.Community{Name: "Test", InacID: nil}
+
+	err := repo.UpsertByInacID(ctx, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inac_id is required")
+}
+
+func TestCommunityRepository_UpsertByStatCanCSD_NilCSD(t *testing.T) {
+	repo, _, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	c := &models.Community{Name: "Test", StatCanCSD: nil}
+
+	err := repo.UpsertByStatCanCSD(ctx, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "statcan_csd is required")
+}
+
+func TestBuildCommunityWhere_NoFilter(t *testing.T) {
+	where, args := buildCommunityWhere(models.CommunityFilter{})
+	assert.Empty(t, where)
+	assert.Nil(t, args)
+}
+
+func TestBuildCommunityWhere_TypeFilter(t *testing.T) {
+	where, args := buildCommunityWhere(models.CommunityFilter{Type: "city"})
+	assert.Contains(t, where, "community_type = $1")
+	require.Len(t, args, 1)
+	assert.Equal(t, "city", args[0])
+}
+
+func TestBuildCommunityWhere_ProvinceFilter(t *testing.T) {
+	where, args := buildCommunityWhere(models.CommunityFilter{Province: "ON"})
+	assert.Contains(t, where, "province = $1")
+	require.Len(t, args, 1)
+}
+
+func TestBuildCommunityWhere_SearchFilter(t *testing.T) {
+	where, args := buildCommunityWhere(models.CommunityFilter{Search: "sudbury"})
+	assert.Contains(t, where, "name ILIKE")
+	require.Len(t, args, 1)
+	assert.Equal(t, "%sudbury%", args[0])
+}
+
+func TestBuildCommunityWhere_Combined(t *testing.T) {
+	where, args := buildCommunityWhere(models.CommunityFilter{
+		Type:     "first_nation",
+		Province: "ON",
+		Search:   "wiki",
+	})
+	assert.Contains(t, where, "community_type")
+	assert.Contains(t, where, "province")
+	assert.Contains(t, where, "ILIKE")
+	require.Len(t, args, 3)
+}
+
+func TestCommunityRepository_UpdateLastScrapedAt_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET last_scraped_at")).
+		WithArgs("c-1", now).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.UpdateLastScrapedAt(ctx, "c-1", now)
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_UpdateLastScrapedAt_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET last_scraped_at")).
+		WithArgs("missing", now).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.UpdateLastScrapedAt(ctx, "missing", now)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_Update_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	c := &models.Community{ID: "missing", Name: "Test", Slug: "test"}
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE communities SET")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.Update(ctx, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCommunityRepository_Create_DBError(t *testing.T) {
+	repo, mock, cleanup := newMockCommunityRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	c := &models.Community{Name: "Fail", Slug: "fail", DataSource: "test"}
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO communities")).
+		WillReturnError(errors.New("duplicate key"))
+
+	err := repo.Create(ctx, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create community")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/source-manager/internal/repository/source_list_mock_test.go
+++ b/source-manager/internal/repository/source_list_mock_test.go
@@ -1,0 +1,229 @@
+//nolint:testpackage // Testing with sqlmock requires same-package access for helper
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sourceListColumns() []string {
+	return []string{
+		"id", "name", "url", "rate_limit", "max_depth",
+		"time", "selectors", "enabled",
+		"feed_url", "sitemap_url", "ingestion_mode", "feed_poll_interval_minutes",
+		"feed_disabled_at", "feed_disable_reason",
+		"allow_source_discovery", "identity_key", "extraction_profile", "template_hint",
+		"render_mode", "type", "indigenous_region",
+		"disabled_at", "disable_reason",
+		"created_at", "updated_at",
+	}
+}
+
+func addSourceRow(rows *sqlmock.Rows, id, name string) {
+	now := time.Now()
+	selectorsJSON := []byte(`{"article":{"title":"h1"},"list":{},"page":{}}`)
+	timeJSON := []byte(`["09:00"]`)
+
+	rows.AddRow(
+		id, name, "https://example.com/"+id, "1s", 2,
+		timeJSON, selectorsJSON, true,
+		nil, nil, "crawl", 0,
+		nil, nil,
+		false, nil, nil, nil,
+		"static", "news", nil,
+		nil, nil,
+		now, now,
+	)
+}
+
+func TestSourceRepository_List_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows(sourceListColumns())
+	addSourceRow(rows, "id-1", "Alpha Source")
+	addSourceRow(rows, "id-2", "Beta Source")
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WillReturnRows(rows)
+
+	sources, err := repo.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+	assert.Equal(t, "Alpha Source", sources[0].Name)
+	assert.Equal(t, "Beta Source", sources[1].Name)
+	// Verify MergeWithDefaults was applied
+	assert.NotEmpty(t, sources[0].Selectors.Article.Container)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_List_EmptyResult(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WillReturnRows(sqlmock.NewRows(sourceListColumns()))
+
+	sources, err := repo.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, sources)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_ListPaginated_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows(sourceListColumns())
+	addSourceRow(rows, "id-1", "Source 1")
+
+	mock.ExpectQuery("SELECT id, name, url").
+		WithArgs(10, 0).
+		WillReturnRows(rows)
+
+	sources, err := repo.ListPaginated(ctx, ListFilter{
+		Limit:  10,
+		Offset: 0,
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, "Source 1", sources[0].Name)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_ListPaginated_WithSearch(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows(sourceListColumns())
+	addSourceRow(rows, "id-1", "CBC News")
+
+	mock.ExpectQuery("SELECT id, name, url").
+		WithArgs("%cbc%", 20, 0).
+		WillReturnRows(rows)
+
+	sources, err := repo.ListPaginated(ctx, ListFilter{
+		Limit:  20,
+		Offset: 0,
+		Search: "cbc",
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_ListPaginated_WithEnabledFilter(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows(sourceListColumns())
+	addSourceRow(rows, "id-1", "Enabled Source")
+
+	enabled := true
+	mock.ExpectQuery("SELECT id, name, url").
+		WithArgs(true, 100, 0).
+		WillReturnRows(rows)
+
+	sources, err := repo.ListPaginated(ctx, ListFilter{
+		Limit:   100,
+		Offset:  0,
+		Enabled: &enabled,
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_GetByIdentityKey_Found(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows(sourceListColumns())
+	addSourceRow(rows, "id-1", "Found Source")
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("example.com/news").
+		WillReturnRows(rows)
+
+	source, err := repo.GetByIdentityKey(ctx, "example.com/news")
+	require.NoError(t, err)
+	require.NotNil(t, source)
+	assert.Equal(t, "Found Source", source.Name)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_GetByIdentityKey_NotFound(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("no-match").
+		WillReturnRows(sqlmock.NewRows(sourceListColumns()))
+
+	source, err := repo.GetByIdentityKey(ctx, "no-match")
+	require.NoError(t, err)
+	assert.Nil(t, source)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_Update_Success_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	source := &models.Source{
+		ID:        "upd-id",
+		Name:      "Updated",
+		URL:       "https://updated.com",
+		RateLimit: "5s",
+		MaxDepth:  3,
+		Selectors: models.SelectorConfig{},
+		Time:      models.StringArray{"09:00"},
+		Enabled:   true,
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs(
+			source.ID, source.Name, source.URL, source.RateLimit, source.MaxDepth,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), // time, selectors
+			source.Enabled,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), // updated_at
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.Update(ctx, source)
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/source-manager/internal/repository/source_mock_test.go
+++ b/source-manager/internal/repository/source_mock_test.go
@@ -1,0 +1,369 @@
+//nolint:testpackage // Testing unexported functions requires same-package access
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger(t *testing.T) infralogger.Logger {
+	t.Helper()
+	log, err := infralogger.New(infralogger.Config{
+		Level:       "debug",
+		Format:      "json",
+		Development: false,
+	})
+	require.NoError(t, err)
+	return log
+}
+
+func newMockSourceRepo(t *testing.T) (*SourceRepository, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	repo := NewSourceRepository(db, newTestLogger(t))
+	cleanup := func() {
+		mock.ExpectClose()
+		db.Close()
+	}
+
+	return repo, mock, cleanup
+}
+
+func TestSourceRepository_Create_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	source := &models.Source{
+		Name:      "Test Source",
+		URL:       "https://example.com",
+		RateLimit: "1s",
+		MaxDepth:  2,
+		Time:      models.StringArray{"09:00"},
+		Selectors: models.SelectorConfig{
+			Article: models.ArticleSelectors{Title: "h1"},
+		},
+		Enabled: true,
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO sources")).
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			source.Name, source.URL, source.RateLimit, source.MaxDepth,
+			sqlmock.AnyArg(), // time JSON
+			sqlmock.AnyArg(), // selectors JSON
+			source.Enabled,
+			sqlmock.AnyArg(), // feed_url
+			sqlmock.AnyArg(), // sitemap_url
+			sqlmock.AnyArg(), // ingestion_mode
+			sqlmock.AnyArg(), // feed_poll_interval_minutes
+			sqlmock.AnyArg(), // allow_source_discovery
+			sqlmock.AnyArg(), // identity_key
+			sqlmock.AnyArg(), // extraction_profile
+			sqlmock.AnyArg(), // template_hint
+			sqlmock.AnyArg(), // render_mode
+			sqlmock.AnyArg(), // type
+			sqlmock.AnyArg(), // indigenous_region
+			sqlmock.AnyArg(), // created_at
+			sqlmock.AnyArg(), // updated_at
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.Create(ctx, source)
+	require.NoError(t, err)
+	assert.NotEmpty(t, source.ID)
+	assert.False(t, source.CreatedAt.IsZero())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_GetByID_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	selectorsJSON := []byte(`{"article":{"title":"h1"},"list":{},"page":{}}`)
+	timeJSON := []byte(`["09:00"]`)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("test-id").
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "name", "url", "rate_limit", "max_depth",
+				"time", "selectors", "enabled",
+				"feed_url", "sitemap_url", "ingestion_mode", "feed_poll_interval_minutes",
+				"feed_disabled_at", "feed_disable_reason",
+				"allow_source_discovery", "identity_key", "extraction_profile", "template_hint",
+				"render_mode", "type", "indigenous_region",
+				"disabled_at", "disable_reason",
+				"created_at", "updated_at",
+			}).AddRow(
+				"test-id", "Test Source", "https://example.com", "1s", 2,
+				timeJSON, selectorsJSON, true,
+				nil, nil, "crawl", 0,
+				nil, nil,
+				false, nil, nil, nil,
+				"static", "news", nil,
+				nil, nil,
+				now, now,
+			),
+		)
+
+	source, err := repo.GetByID(ctx, "test-id")
+	require.NoError(t, err)
+	require.NotNil(t, source)
+	assert.Equal(t, "test-id", source.ID)
+	assert.Equal(t, "Test Source", source.Name)
+	assert.Equal(t, "https://example.com", source.URL)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_GetByID_NotFound_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, url")).
+		WithArgs("not-found-id").
+		WillReturnRows(sqlmock.NewRows(nil))
+
+	source, err := repo.GetByID(ctx, "not-found-id")
+	require.Error(t, err)
+	assert.Nil(t, source)
+	assert.Contains(t, err.Error(), "source not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_Delete_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		mock.ExpectExec(regexp.QuoteMeta("DELETE FROM sources WHERE id = $1")).
+			WithArgs("del-id").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := repo.Delete(ctx, "del-id")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mock.ExpectExec(regexp.QuoteMeta("DELETE FROM sources WHERE id = $1")).
+			WithArgs("missing-id").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		err := repo.Delete(ctx, "missing-id")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSourceNotFound)
+	})
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_Update_NotFound_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	source := &models.Source{
+		ID:        "missing-id",
+		Name:      "Test",
+		URL:       "https://example.com",
+		RateLimit: "1s",
+		Selectors: models.SelectorConfig{},
+		Time:      models.StringArray{"09:00"},
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs(
+			source.ID, source.Name, source.URL, source.RateLimit, source.MaxDepth,
+			sqlmock.AnyArg(), // time
+			sqlmock.AnyArg(), // selectors
+			source.Enabled,
+			sqlmock.AnyArg(), // feed_url
+			sqlmock.AnyArg(), // sitemap_url
+			sqlmock.AnyArg(), // ingestion_mode
+			sqlmock.AnyArg(), // feed_poll_interval_minutes
+			sqlmock.AnyArg(), // allow_source_discovery
+			sqlmock.AnyArg(), // identity_key
+			sqlmock.AnyArg(), // extraction_profile
+			sqlmock.AnyArg(), // template_hint
+			sqlmock.AnyArg(), // render_mode
+			sqlmock.AnyArg(), // type
+			sqlmock.AnyArg(), // indigenous_region
+			sqlmock.AnyArg(), // updated_at
+		).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.Update(ctx, source)
+	require.ErrorIs(t, err, ErrSourceNotFound)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_DisableFeed_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+			WithArgs("src-id", "not_found").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := repo.DisableFeed(ctx, "src-id", "not_found")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+			WithArgs("missing-id", "gone").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		err := repo.DisableFeed(ctx, "missing-id", "gone")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSourceNotFound)
+	})
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_EnableFeed_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+			WithArgs("src-id").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := repo.EnableFeed(ctx, "src-id")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+			WithArgs("missing-id").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		err := repo.EnableFeed(ctx, "missing-id")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSourceNotFound)
+	})
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_DisableSource_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("src-id", "maintenance").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.DisableSource(ctx, "src-id", "maintenance")
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_EnableSource_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE sources")).
+		WithArgs("src-id").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.EnableSource(ctx, "src-id")
+	require.NoError(t, err)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_GetByIdentityKey_Empty(t *testing.T) {
+	repo, _, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	source, err := repo.GetByIdentityKey(ctx, "")
+	require.NoError(t, err)
+	assert.Nil(t, source)
+}
+
+func TestSourceRepository_Count_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM sources WHERE 1=1")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(42))
+
+	count, err := repo.Count(ctx, ListFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 42, count)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_GetCities_Mock(t *testing.T) {
+	repo, mock, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT name as source_name")).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"source_name"}).
+				AddRow("CBC News").
+				AddRow("Global News"),
+		)
+
+	cities, err := repo.GetCities(ctx)
+	require.NoError(t, err)
+	require.Len(t, cities, 2)
+	assert.Equal(t, "CBC News", cities[0].Name)
+	assert.Contains(t, cities[0].Index, "cbc_news")
+	assert.Equal(t, "Global News", cities[1].Name)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSourceRepository_UpsertSourcesTx_Empty(t *testing.T) {
+	repo, _, cleanup := newMockSourceRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	created, updated, err := repo.UpsertSourcesTx(ctx, []*models.Source{})
+	require.NoError(t, err)
+	assert.Nil(t, created)
+	assert.Nil(t, updated)
+}

--- a/source-manager/internal/repository/source_unit_test.go
+++ b/source-manager/internal/repository/source_unit_test.go
@@ -1,0 +1,172 @@
+//nolint:testpackage // Testing unexported functions requires same-package access
+package repository
+
+import (
+	"testing"
+
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildListWhere_NoFilters(t *testing.T) {
+	t.Helper()
+	filter := ListFilter{}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Empty(t, whereClause)
+	assert.Empty(t, args)
+}
+
+func TestBuildListWhere_SearchFilter(t *testing.T) {
+	t.Helper()
+	filter := ListFilter{Search: "example"}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Contains(t, whereClause, "name ILIKE")
+	assert.Contains(t, whereClause, "url ILIKE")
+	require.Len(t, args, 1)
+	assert.Equal(t, "%example%", args[0])
+}
+
+func TestBuildListWhere_EnabledFilter(t *testing.T) {
+	t.Helper()
+	enabled := true
+	filter := ListFilter{Enabled: &enabled}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Contains(t, whereClause, "enabled = $1")
+	require.Len(t, args, 1)
+	assert.Equal(t, true, args[0])
+}
+
+func TestBuildListWhere_DisabledFilter(t *testing.T) {
+	t.Helper()
+	enabled := false
+	filter := ListFilter{Enabled: &enabled}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Contains(t, whereClause, "enabled = $1")
+	require.Len(t, args, 1)
+	assert.Equal(t, false, args[0])
+}
+
+func TestBuildListWhere_FeedActiveFilter(t *testing.T) {
+	t.Helper()
+	active := true
+	filter := ListFilter{FeedActive: &active}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Contains(t, whereClause, "feed_disabled_at IS NULL")
+	assert.Empty(t, args)
+}
+
+func TestBuildListWhere_IndigenousOnlyFilter(t *testing.T) {
+	t.Helper()
+	filter := ListFilter{IndigenousOnly: true}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Contains(t, whereClause, "indigenous_region IS NOT NULL")
+	assert.Empty(t, args)
+}
+
+func TestBuildListWhere_CombinedFilters(t *testing.T) {
+	t.Helper()
+	enabled := true
+	filter := ListFilter{
+		Search:         "news",
+		Enabled:        &enabled,
+		IndigenousOnly: true,
+	}
+
+	whereClause, args := buildListWhere(filter)
+	assert.Contains(t, whereClause, "ILIKE")
+	assert.Contains(t, whereClause, "enabled")
+	assert.Contains(t, whereClause, "indigenous_region IS NOT NULL")
+	require.Len(t, args, 2) // search + enabled
+}
+
+func TestBuildListOrder_DefaultValues(t *testing.T) {
+	t.Helper()
+	filter := ListFilter{}
+
+	orderClause := buildListOrder(filter)
+	assert.Equal(t, " ORDER BY name ASC", orderClause)
+}
+
+func TestBuildListOrder_ValidSortBy(t *testing.T) {
+	t.Helper()
+	tests := []struct {
+		name      string
+		sortBy    string
+		sortOrder string
+		expected  string
+	}{
+		{"sort by name asc", "name", "asc", " ORDER BY name ASC"},
+		{"sort by url desc", "url", "desc", " ORDER BY url DESC"},
+		{"sort by enabled asc", "enabled", "asc", " ORDER BY enabled ASC"},
+		{"sort by created_at desc", "created_at", "desc", " ORDER BY created_at DESC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := ListFilter{SortBy: tt.sortBy, SortOrder: tt.sortOrder}
+			assert.Equal(t, tt.expected, buildListOrder(filter))
+		})
+	}
+}
+
+func TestBuildListOrder_InvalidSortBy(t *testing.T) {
+	t.Helper()
+	filter := ListFilter{SortBy: "DROP TABLE sources;", SortOrder: "asc"}
+
+	orderClause := buildListOrder(filter)
+	assert.Equal(t, " ORDER BY name ASC", orderClause)
+}
+
+func TestBuildListOrder_InvalidSortOrder(t *testing.T) {
+	t.Helper()
+	filter := ListFilter{SortBy: "name", SortOrder: "invalid"}
+
+	orderClause := buildListOrder(filter)
+	assert.Equal(t, " ORDER BY name ASC", orderClause)
+}
+
+func TestDeriveClassifiedContentIndex(t *testing.T) {
+	t.Helper()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"normal name", "Example News", "example_news_classified_content"},
+		{"empty name", "", "unknown_classified_content"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveClassifiedContentIndex(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestMarshalExtractionProfile_Nil(t *testing.T) {
+	t.Helper()
+	result := marshalExtractionProfile(nil)
+	assert.Nil(t, result)
+}
+
+func TestMarshalExtractionProfile_Empty(t *testing.T) {
+	t.Helper()
+	profile := models.ExtractionProfileJSON{}
+	result := marshalExtractionProfile(&profile)
+	assert.Nil(t, result)
+}
+
+func TestMarshalExtractionProfile_WithData(t *testing.T) {
+	t.Helper()
+	data := models.ExtractionProfileJSON(`{"key":"value"}`)
+	result := marshalExtractionProfile(&data)
+	assert.JSONEq(t, `{"key":"value"}`, string(result))
+}

--- a/source-manager/internal/seeder/cirnac_test.go
+++ b/source-manager/internal/seeder/cirnac_test.go
@@ -1,0 +1,231 @@
+//nolint:testpackage // Testing unexported CSV parsing helpers requires same-package access
+package seeder
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"testing"
+
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger(t *testing.T) infralogger.Logger {
+	t.Helper()
+	log, err := infralogger.New(infralogger.Config{
+		Level:       "debug",
+		Format:      "json",
+		Development: false,
+	})
+	require.NoError(t, err)
+	return log
+}
+
+func TestBuildColumnIndex(t *testing.T) {
+	t.Parallel()
+
+	header := []string{"BAND_NUMBER", "BAND_NAME", "LATITUDE", "LONGITUDE"}
+	idx := buildColumnIndex(header)
+
+	assert.Equal(t, 0, idx["BAND_NUMBER"])
+	assert.Equal(t, 1, idx["BAND_NAME"])
+	assert.Equal(t, 2, idx["LATITUDE"])
+	assert.Equal(t, 3, idx["LONGITUDE"])
+}
+
+func TestBuildColumnIndex_WithSpaces(t *testing.T) {
+	t.Parallel()
+
+	header := []string{" BAND_NUMBER ", "BAND_NAME"}
+	idx := buildColumnIndex(header)
+
+	assert.Equal(t, 0, idx["BAND_NUMBER"])
+	assert.Equal(t, 1, idx["BAND_NAME"])
+}
+
+func TestValidateColumns_AllPresent(t *testing.T) {
+	t.Parallel()
+
+	colIndex := map[string]int{
+		"BAND_NUMBER": 0,
+		"BAND_NAME":   1,
+		"LATITUDE":    2,
+		"LONGITUDE":   3,
+	}
+	err := validateColumns(colIndex)
+	assert.NoError(t, err)
+}
+
+func TestValidateColumns_MissingColumn(t *testing.T) {
+	t.Parallel()
+
+	colIndex := map[string]int{
+		"BAND_NUMBER": 0,
+		"BAND_NAME":   1,
+		// LATITUDE and LONGITUDE missing
+	}
+	err := validateColumns(colIndex)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required column")
+}
+
+func TestParseCoords_ValidCoords(t *testing.T) {
+	t.Parallel()
+
+	record := []string{"123", "Test Band", "46.49", "-81.00"}
+	colIndex := map[string]int{
+		"LATITUDE":  2,
+		"LONGITUDE": 3,
+	}
+
+	lat, lng := parseCoords(record, colIndex)
+	require.NotNil(t, lat)
+	require.NotNil(t, lng)
+	assert.InDelta(t, 46.49, *lat, 0.001)
+	assert.InDelta(t, -81.00, *lng, 0.001)
+}
+
+func TestParseCoords_EmptyStrings(t *testing.T) {
+	t.Parallel()
+
+	record := []string{"123", "Test Band", "", ""}
+	colIndex := map[string]int{
+		"LATITUDE":  2,
+		"LONGITUDE": 3,
+	}
+
+	lat, lng := parseCoords(record, colIndex)
+	assert.Nil(t, lat)
+	assert.Nil(t, lng)
+}
+
+func TestParseCoords_InvalidValues(t *testing.T) {
+	t.Parallel()
+
+	record := []string{"123", "Test Band", "not-a-number", "-81.00"}
+	colIndex := map[string]int{
+		"LATITUDE":  2,
+		"LONGITUDE": 3,
+	}
+
+	lat, lng := parseCoords(record, colIndex)
+	assert.Nil(t, lat)
+	assert.Nil(t, lng)
+}
+
+func TestBuildCommunity(t *testing.T) {
+	t.Parallel()
+
+	lat := 46.49
+	lng := -81.00
+	c := buildCommunity("123", "Test First Nation", "ON", &lat, &lng)
+
+	assert.Equal(t, "Test First Nation", c.Name)
+	assert.Equal(t, "test-first-nation", c.Slug)
+	assert.Equal(t, communityTypeFN, c.CommunityType)
+	assert.Equal(t, "123", *c.InacID)
+	assert.Equal(t, "ON", *c.Province)
+	assert.InDelta(t, 46.49, *c.Latitude, 0.001)
+	assert.InDelta(t, -81.00, *c.Longitude, 0.001)
+	assert.Equal(t, dataSourceCIRNAC, c.DataSource)
+	assert.True(t, c.Enabled)
+}
+
+func TestBuildCommunity_EmptyProvince(t *testing.T) {
+	t.Parallel()
+
+	c := buildCommunity("456", "Band Name", "", nil, nil)
+
+	assert.Equal(t, "Band Name", c.Name)
+	assert.Nil(t, c.Province)
+	assert.Nil(t, c.Latitude)
+	assert.Nil(t, c.Longitude)
+}
+
+func TestSeedFromReader_ValidCSV(t *testing.T) {
+	t.Parallel()
+
+	csvData := "BAND_NUMBER,BAND_NAME,LATITUDE,LONGITUDE\n" +
+		"100,Test First Nation,46.49,-81.00\n" +
+		"200,Second Band,48.47,-81.33\n"
+
+	reader := csv.NewReader(bytes.NewReader([]byte(csvData)))
+
+	seeder := &CIRNACSeeder{
+		repo:   nil,
+		logger: testLogger(t),
+	}
+
+	result, err := seeder.seedFromReader(context.Background(), reader, true) // dryRun=true
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Total)
+	assert.Equal(t, 2, result.WouldCreate)
+	assert.Equal(t, 0, result.Errors)
+	assert.Equal(t, 0, result.Skipped)
+}
+
+func TestSeedFromReader_SkipsMissingBandNumber(t *testing.T) {
+	t.Parallel()
+
+	csvData := "BAND_NUMBER,BAND_NAME,LATITUDE,LONGITUDE\n" +
+		",Missing Number,46.49,-81.00\n"
+
+	reader := csv.NewReader(bytes.NewReader([]byte(csvData)))
+
+	seeder := &CIRNACSeeder{
+		repo:   nil,
+		logger: testLogger(t),
+	}
+
+	result, err := seeder.seedFromReader(context.Background(), reader, true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total)
+	assert.Equal(t, 0, result.WouldCreate)
+	assert.Equal(t, 1, result.Skipped)
+}
+
+func TestSeedFromReader_SkipsMissingBandName(t *testing.T) {
+	t.Parallel()
+
+	csvData := "BAND_NUMBER,BAND_NAME,LATITUDE,LONGITUDE\n" +
+		"100,,46.49,-81.00\n"
+
+	reader := csv.NewReader(bytes.NewReader([]byte(csvData)))
+
+	seeder := &CIRNACSeeder{
+		repo:   nil,
+		logger: testLogger(t),
+	}
+
+	result, err := seeder.seedFromReader(context.Background(), reader, true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total)
+	assert.Equal(t, 0, result.WouldCreate)
+	assert.Equal(t, 1, result.Skipped)
+}
+
+func TestSeedFromReader_MissingRequiredColumn(t *testing.T) {
+	t.Parallel()
+
+	csvData := "BAND_NUMBER,MISSING_COLUMN\n100,data\n"
+
+	reader := csv.NewReader(bytes.NewReader([]byte(csvData)))
+
+	seeder := &CIRNACSeeder{
+		repo:   nil,
+		logger: testLogger(t),
+	}
+
+	_, err := seeder.seedFromReader(context.Background(), reader, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required column")
+}
+
+func TestNewCIRNACSeeder(t *testing.T) {
+	t.Parallel()
+
+	seeder := NewCIRNACSeeder(nil, nil)
+	assert.NotNil(t, seeder)
+}

--- a/source-manager/internal/services/source_service_test.go
+++ b/source-manager/internal/services/source_service_test.go
@@ -1,0 +1,56 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/jonesrussell/north-cloud/source-manager/internal/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeFloat_NilPointer(t *testing.T) {
+	t.Parallel()
+	result := services.SafeFloat(nil)
+	assert.InDelta(t, 0.0, result, 0.0001)
+}
+
+func TestSafeFloat_ZeroValue(t *testing.T) {
+	t.Parallel()
+	val := 0.0
+	result := services.SafeFloat(&val)
+	assert.InDelta(t, 0.0, result, 0.0001)
+}
+
+func TestSafeFloat_PositiveValue(t *testing.T) {
+	t.Parallel()
+	val := 42.5
+	result := services.SafeFloat(&val)
+	assert.InDelta(t, 42.5, result, 0.0001)
+}
+
+func TestSafeFloat_NegativeValue(t *testing.T) {
+	t.Parallel()
+	val := -15.75
+	result := services.SafeFloat(&val)
+	assert.InDelta(t, -15.75, result, 0.0001)
+}
+
+func TestSafeFloat_LargeValue(t *testing.T) {
+	t.Parallel()
+	val := 1e18
+	result := services.SafeFloat(&val)
+	assert.InDelta(t, 1e18, result, 1e12)
+}
+
+func TestSafeFloat_SmallValue(t *testing.T) {
+	t.Parallel()
+	val := 1e-10
+	result := services.SafeFloat(&val)
+	assert.InDelta(t, 1e-10, result, 1e-15)
+}
+
+func TestNewTravelTimeService(t *testing.T) {
+	t.Parallel()
+	// Verify constructor does not panic with nil args
+	svc := services.NewTravelTimeService(nil, nil, nil, nil)
+	assert.NotNil(t, svc)
+}

--- a/source-manager/internal/services/travel_time_internal_test.go
+++ b/source-manager/internal/services/travel_time_internal_test.go
@@ -1,0 +1,223 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/models"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/repository"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/services/osrm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger(t *testing.T) infralogger.Logger {
+	t.Helper()
+	log, err := infralogger.New(infralogger.Config{
+		Level:       "debug",
+		Format:      "json",
+		Development: false,
+	})
+	require.NoError(t, err)
+	return log
+}
+
+func TestCacheResult_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	log := testLogger(t)
+	travelRepo := repository.NewTravelTimeRepository(db, log)
+	svc := NewTravelTimeService(nil, travelRepo, nil, log)
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO travel_time_cache")).
+		WithArgs("origin-1", "dest-1", "driving",
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	result := &osrm.TravelTimeResult{
+		DurationSeconds: 3600,
+		DistanceMeters:  50000,
+	}
+
+	// Should not panic even though it's fire-and-forget
+	svc.cacheResult(context.Background(), "origin-1", "dest-1", "driving", result)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCacheResult_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	log := testLogger(t)
+	travelRepo := repository.NewTravelTimeRepository(db, log)
+	svc := NewTravelTimeService(nil, travelRepo, nil, log)
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO travel_time_cache")).
+		WillReturnError(errors.New("db error"))
+
+	result := &osrm.TravelTimeResult{
+		DurationSeconds: 100,
+		DistanceMeters:  1000,
+	}
+
+	// Should log warning but not panic
+	svc.cacheResult(context.Background(), "origin-1", "dest-1", "walking", result)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestComputeSingle_CacheHit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	log := testLogger(t)
+	travelRepo := repository.NewTravelTimeRepository(db, log)
+	svc := NewTravelTimeService(nil, travelRepo, nil, log)
+
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, origin_community_id")).
+		WithArgs("origin-1", "dest-1", "driving").
+		WillReturnRows(
+			sqlmock.NewRows([]string{
+				"id", "origin_community_id", "destination_community_id",
+				"transport_mode", "duration_seconds", "distance_meters", "computed_at",
+			}).AddRow(
+				1, "origin-1", "dest-1",
+				"driving", 1800, 30000, now,
+			),
+		)
+
+	originLat, originLon := 46.49, -81.0
+	origin := &models.Community{
+		ID:        "origin-1",
+		Name:      "Sudbury",
+		Latitude:  &originLat,
+		Longitude: &originLon,
+	}
+
+	destLat, destLon := 48.47, -81.33
+	dest := &models.CommunityWithDistance{
+		Community: models.Community{
+			ID:        "dest-1",
+			Name:      "Timmins",
+			Latitude:  &destLat,
+			Longitude: &destLon,
+		},
+		DistanceKm: 220,
+	}
+
+	cwt, computeErr := svc.computeSingle(context.Background(), origin, dest, "driving")
+	require.NoError(t, computeErr)
+	require.NotNil(t, cwt)
+	assert.Equal(t, "dest-1", cwt.CommunityID)
+	assert.Equal(t, "Timmins", cwt.Name)
+	assert.InDelta(t, 30.0, cwt.DurationMinutes, 0.001)
+	assert.InDelta(t, 30.0, cwt.DistanceKm, 0.001)
+	assert.Equal(t, "driving", cwt.TransportMode)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestComputeSingle_NoCoordsOnDest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	log := testLogger(t)
+	travelRepo := repository.NewTravelTimeRepository(db, log)
+	svc := NewTravelTimeService(nil, travelRepo, nil, log)
+
+	// Return no cached entry
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, origin_community_id")).
+		WithArgs("origin-1", "dest-no-coords", "driving").
+		WillReturnRows(sqlmock.NewRows(nil))
+
+	originLat, originLon := 46.49, -81.0
+	origin := &models.Community{
+		ID:        "origin-1",
+		Latitude:  &originLat,
+		Longitude: &originLon,
+	}
+
+	dest := &models.CommunityWithDistance{
+		Community: models.Community{
+			ID:        "dest-no-coords",
+			Name:      "No Coords",
+			Latitude:  nil,
+			Longitude: nil,
+		},
+	}
+
+	cwt, computeErr := svc.computeSingle(context.Background(), origin, dest, "driving")
+	require.Error(t, computeErr)
+	assert.Nil(t, cwt)
+	assert.Contains(t, computeErr.Error(), "no coordinates")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestComputeMatrix_OriginNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	log := testLogger(t)
+	communityRepo := repository.NewCommunityRepository(db, log)
+	svc := NewTravelTimeService(nil, nil, communityRepo, log)
+
+	// Return empty for GetByID
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, slug")).
+		WithArgs("nonexistent").
+		WillReturnRows(sqlmock.NewRows(nil))
+
+	_, computeErr := svc.ComputeMatrix(context.Background(), "nonexistent", 100, 60, "driving")
+	require.Error(t, computeErr)
+	assert.Contains(t, computeErr.Error(), "not found")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestComputeMatrix_OriginNoCoords(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	log := testLogger(t)
+	communityRepo := repository.NewCommunityRepository(db, log)
+	svc := NewTravelTimeService(nil, nil, communityRepo, log)
+
+	now := time.Now()
+	cols := []string{
+		"id", "name", "slug", "community_type", "province", "region",
+		"inac_id", "statcan_csd", "osm_relation_id", "wikidata_qid", "latitude", "longitude",
+		"nation", "treaty", "language_group", "reserve_name", "population", "population_year",
+		"website", "feed_url", "data_source", "source_id", "enabled", "created_at", "updated_at",
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, slug")).
+		WithArgs("no-coords").
+		WillReturnRows(
+			sqlmock.NewRows(cols).AddRow(
+				"no-coords", "No Coords", "no-coords", "city", nil, nil,
+				nil, nil, nil, nil, nil, nil,
+				nil, nil, nil, nil, nil, nil,
+				nil, nil, "manual", nil, true, now, now,
+			),
+		)
+
+	_, computeErr := svc.ComputeMatrix(context.Background(), "no-coords", 100, 60, "driving")
+	require.Error(t, computeErr)
+	assert.Contains(t, computeErr.Error(), "no coordinates")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
Part of #537 — critical test coverage gaps.

See commit messages for per-package coverage improvements.

## Test plan
- [x] All new tests pass
- [x] Lint passes
- [x] Spec drift check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)