### PR TITLE
feat: replace search-frontend with northcloud-search services

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -280,20 +280,46 @@ services:
       retries: 3
       start_period: 10s
 
-  search-frontend:
+  northcloud-search-web:
     <<: *service-defaults
-    # No profiles here so prod always has search-frontend; dev overrides with profiles: [search]
     build:
-      context: ./search-frontend
+      context: ../northcloud-search
       dockerfile: Dockerfile
-    image: docker.io/jonesrussell/search-frontend:latest
+    image: docker.io/jonesrussell/northcloud-search:latest
+    container_name: north-cloud-northcloud-search-web
+    ports:
+      - "3003:3003"
+    volumes:
+      - northcloud-search-data:/app/storage
     deploy:
       resources:
         limits:
           cpus: "0.25"
           memory: 128M
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3003/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  northcloud-search-subscriber:
+    <<: *service-defaults
+    build:
+      context: ../northcloud-search
+      dockerfile: Dockerfile
+    image: docker.io/jonesrussell/northcloud-search:latest
+    container_name: north-cloud-northcloud-search-subscriber
+    command: ["php", "bin/waaseyaa", "app:subscribe", "--redis-url=tcp://redis:6379"]
+    volumes:
+      - northcloud-search-data:/app/storage
     depends_on:
-      - search-service
+      - redis
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+    restart: unless-stopped
 
   auth:
     <<: *service-defaults
@@ -723,6 +749,7 @@ volumes:
   prometheus_data:
   grafana_data:
   nc_http_proxy_cache:
+  northcloud-search-data:
 
 networks:
   north-cloud-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -419,21 +419,13 @@ services:
       start_period: 20s
 
   # ------------------------------------------------------------
-  # Search Frontend (Prod)
+  # NorthCloud Search (Prod)
   # ------------------------------------------------------------
-  search-frontend:
-    <<: *prod-defaults
-    image: northcloud-search:latest
-    deploy:
-      resources:
-        limits:
-          cpus: "0.25"
-          memory: 128M
-    depends_on:
-      search-service:
-        condition: service_healthy
-    environment:
-      NORTHCLOUD_API_URL: http://search-service:8090
+  northcloud-search-web:
+    image: docker.io/jonesrussell/northcloud-search:${NORTHCLOUD_SEARCH_TAG:-latest}
+
+  northcloud-search-subscriber:
+    image: docker.io/jonesrussell/northcloud-search:${NORTHCLOUD_SEARCH_TAG:-latest}
 
   # ------------------------------------------------------------
   # nc-http-proxy (Prod) - HTTP replay proxy for crawler


### PR DESCRIPTION
## Summary
- Replaced the monolithic `search-frontend` service with two Waaseyaa-based services: `northcloud-search-web` (HTTP server on port 3003) and `northcloud-search-subscriber` (Redis pub/sub consumer)
- Both services share a `northcloud-search-data` Docker volume for the SQLite FTS5 search index
- Updated production overrides in `docker-compose.prod.yml` to use `NORTHCLOUD_SEARCH_TAG` variable

## Test plan
- [ ] Verify `docker compose -f docker-compose.base.yml config` parses without errors
- [ ] Verify `northcloud-search-web` container starts and responds on port 3003
- [ ] Verify `northcloud-search-subscriber` connects to Redis and processes messages
- [ ] Verify shared SQLite volume is accessible from both containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)