### PR TITLE
docs(signal-crawler): add MIGRATION.md pointing to signal-producer

### DIFF
--- a/signal-crawler/CLAUDE.md
+++ b/signal-crawler/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-> **Read first:** [`docs/specs/lead-pipeline.md`](../docs/specs/lead-pipeline.md) defines the shared signal schema, threshold contract, and dedup strategy across all producers. This service is in maintenance mode; new adapters land in `signal-producer` (#592). See `MIGRATION.md` (#641 pending).
+> **Read first:** [`docs/specs/lead-pipeline.md`](../docs/specs/lead-pipeline.md) defines the shared signal schema, threshold contract, and dedup strategy across all producers. This service is in maintenance mode; new adapters land in `signal-producer` (#592). See [`MIGRATION.md`](MIGRATION.md) for the successor direction and the list of adapters that stay here.
 
 ## Overview
 

--- a/signal-crawler/MIGRATION.md
+++ b/signal-crawler/MIGRATION.md
@@ -1,0 +1,42 @@
+# signal-crawler — successor direction
+
+> Read alongside [`docs/specs/lead-pipeline.md`](../docs/specs/lead-pipeline.md).
+
+## Status
+
+**signal-crawler is in maintenance mode.** It continues to run during the transition, but it is not the place where new adapter work lands.
+
+## Successor
+
+The successor is **signal-producer** — the binary specified by the Lead Intelligence Integration milestone (issue #592). signal-producer posts to Waaseyaa (`${WAASEYAA_URL}/api/signals`) using the same wire format this service uses today, with checkpoint persistence and an enrichment-callback pathway that this service does not have.
+
+New adapters land in signal-producer. Procurement sources do not go to either service — they extend the `PortalParser` interface in `rfp-ingestor` instead.
+
+See `docs/specs/lead-pipeline.md` for the producer catalogue, the shared signal schema, the threshold and attribution contracts, and the per-producer dedup keys.
+
+## What still runs here
+
+The following adapters keep running in signal-crawler during the transition. Treat them as examples rather than canonical data sources; none of them should be copied or promoted into signal-producer without a separate decision.
+
+| Adapter | Why it stays here | Next step |
+|---|---|---|
+| `adapter/hn` (HN general) | ICP-mismatched — not part of the prospect engine's target segments | No promotion. Retire when signal-producer replaces the adapter harness. |
+| `adapter/jobs/hnhiring` | ICP-mismatched | No promotion. |
+| `adapter/jobs/wwr` (WeWorkRemotely) | ICP-mismatched | No promotion. |
+| `adapter/jobs/remoteok` | ICP-mismatched | No promotion. |
+| `adapter/jobs/gcjobs` | Marginal for senior-engineering-gap detection; currently blocked by source-side IP filtering | No promotion. |
+| `adapter/jobs/workbc` | Marginal | No promotion. |
+| `adapter/funding/otf` | On-ICP but single-source; broader funding coverage lands in signal-producer | Reimplement in signal-producer when funding adapters land there. |
+
+## What to do when modifying this service
+
+1. Bug fixes and minor adapter tweaks are fine in-place.
+2. New adapters — do not add here. Open an issue under the Lead Intelligence Integration milestone and land them in signal-producer.
+3. Changes to the wire format, threshold gate, attribution rules, or dedup key must reference `docs/specs/lead-pipeline.md` and may need a coordinated change in signal-producer and Waaseyaa.
+4. When signal-producer fully covers the canonical adapters, this service is retired — not on a calendar, but on coverage parity.
+
+## References
+
+- Spec: `docs/specs/lead-pipeline.md`
+- Successor: issue #592 (signal-producer binary) and the surrounding Lead Intelligence Integration milestone
+- Prospect engine overview: `docs/prospect-engine-plan.md`


### PR DESCRIPTION
## Summary

- Adds `signal-crawler/MIGRATION.md` documenting signal-crawler as in-maintenance-mode and naming signal-producer (#592) as its successor
- Resolves the `(#641 pending)` placeholder in `signal-crawler/CLAUDE.md` banner by linking directly to `MIGRATION.md`
- Lists the adapters that stay in signal-crawler during the transition and what to do when modifying this service

## Context

Part of wave 1 of the prospect-engine plan. Stacked on #642 (lead-pipeline umbrella spec) because MIGRATION.md links to `docs/specs/lead-pipeline.md`, which lands in that PR.

Per design discipline, the link in MIGRATION.md points to the spec as a whole rather than specific section numbers — section numbering is the most likely thing to shift in review.

Closes #641.

## Test plan

- [ ] Verify `signal-crawler/MIGRATION.md` renders correctly on GitHub
- [ ] Verify the link to `docs/specs/lead-pipeline.md` resolves after #642 merges
- [ ] Verify `signal-crawler/CLAUDE.md` banner links to MIGRATION.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)