### PR TITLE
refactor(classifier): preallocate allNeedSignalKeywords slice

### DIFF
--- a/classifier/internal/classifier/need_signal_extractor.go
+++ b/classifier/internal/classifier/need_signal_extractor.go
@@ -55,7 +55,12 @@ var signalCategoryKeywords = map[string][]string{
 // signal category. Used by the heuristic classifier so both components share
 // a single keyword source.
 func allNeedSignalKeywords() []string {
-	var all []string
+	total := 0
+	for _, kws := range signalCategoryKeywords {
+		total += len(kws)
+	}
+
+	all := make([]string, 0, total)
 	for _, kws := range signalCategoryKeywords {
 		all = append(all, kws...)
 	}

--- a/docs/specs/classification.md
+++ b/docs/specs/classification.md
@@ -291,7 +291,7 @@ Added to the content type enumeration. When the keyword heuristic fires, the con
 
 ### Keyword Heuristic Classifier (`classifyFromNeedSignalKeywords`)
 
-Uses `allNeedSignalKeywords()` which flattens the extractor's `signalCategoryKeywords` map — both the heuristic and extractor share a single keyword source. Five keyword categories:
+Uses `allNeedSignalKeywords()` which flattens the extractor's `signalCategoryKeywords` map into a single preallocated slice — both the heuristic and extractor share a single keyword source. Five keyword categories:
 - `outdated_website` — signals an organization has an outdated or broken web presence
 - `funding_win` — grant awards, funding announcements
 - `job_posting` — hiring signals indicating growth or capacity gaps

--- a/docs/specs/lead-pipeline.md
+++ b/docs/specs/lead-pipeline.md
@@ -1,6 +1,6 @@
 # Lead / Signal Pipeline Spec
 
-> Last verified: 2026-04-18 (initial draft — umbrella for signal-crawler, classifier `need_signal`, publisher `/api/leads`, rfp-ingestor, and the Lead Intelligence successor architecture)
+> Last verified: 2026-04-19 (umbrella for signal-crawler, classifier `need_signal`, publisher `/api/leads`, rfp-ingestor, and the Lead Intelligence successor architecture; MIGRATION.md in signal-crawler is already linked from §6)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Precomputes total keyword count across `signalCategoryKeywords` and uses `make([]string, 0, total)` instead of `var all []string` with incremental append growth.
- Clears the `prealloc` lint violation in `classifier/internal/classifier/need_signal_extractor.go:58` that's been red on main since commit 1a310193.
- No behavioral change. Return value is identical.

## Why standalone

Pre-existing breakage on main, blocks #648/#649/#650. Surfaced after the golangci-lint version drift (see #653) — the `prealloc` linter is stricter in the CI-pinned v2.10.1 than in local v2.11.4.

## Test plan
- [x] `GOWORK=off go build ./...` in `classifier/` — clean
- [x] `GOWORK=off go test ./internal/classifier/...` — passes (the helper has direct coverage via `detectSignalType`)
- [x] Local `golangci-lint run` in `classifier/` — 0 issues
- [ ] CI green

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)