### PR TITLE
fix(drift-detector): align service_last_commit exclusions with CHANGED_FILES

### DIFF
--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -142,7 +142,16 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
     service_last_commit=0
     for pattern in "${!PATTERN_TO_SPEC[@]}"; do
       if [ "${PATTERN_TO_SPEC[$pattern]}" = "$spec" ]; then
-        pattern_commit=$(git log -1 --format=%ct -- "$pattern" ':!*/vendor/*' 2>/dev/null)
+        pattern_commit=$(git log -1 --format=%ct -- "$pattern" \
+          ':!*/vendor/*' \
+          ':!*/Dockerfile' \
+          ':!*/go.mod' \
+          ':!*/go.sum' \
+          ':!*/CLAUDE.md' \
+          ':!*/MIGRATION.md' \
+          ':!*/.layers' \
+          ':!*_test.go' \
+          2>/dev/null)
         pattern_commit=${pattern_commit:-0}
         if [ "$pattern_commit" -gt "$service_last_commit" ]; then
           service_last_commit=$pattern_commit


### PR DESCRIPTION
## Summary

One-line-style fix for #657. The drift detector's staleness comparison computes `service_last_commit` via an unfiltered `git log -1` at `tools/drift-detector.sh:145`, so commits touching only excluded paths (Dockerfile, go.mod, etc.) still update the timestamp and flag specs STALE despite `CHANGED_FILES` filtering those same paths out.

Aligns the `git log -1` pathspec exclusions with the existing `CHANGED_FILES` `grep -v` filter list.

## Semantic narrowing — please read before merging

This fix makes the exclusion list authoritative. The drift gate now treats **"service drift" as "public-contract / behavioural source drift"**, explicitly excluding:

- `**/Dockerfile` — container/runtime config
- `**/go.mod`, `**/go.sum` — dependency versions
- `**/CLAUDE.md` — Claude instructions
- `**/MIGRATION.md` — migration notes
- `**/.layers` — layer-check config
- `**_test.go` — test code
- `**/vendor/*` — vendored deps

**Consequence:** a major dependency bump with real behavioural consequences (e.g. a breaking change in a Go stdlib package surfacing as a behavioural shift) will no longer trigger a spec review through this gate. That kind of change has to be caught by code review or a separate mechanism (e.g. a dependency-audit workflow).

This is a deliberate narrowing. The previous behaviour was accidental — `CHANGED_FILES` already excluded the same paths; the `service_last_commit` query just didn't get the memo.

## Verification

Scenarios tested locally:

1. **Clean main (20-commit CI window):** all affected specs OK, no STALE. ✅
2. **Excluded-only commit** (Dockerfile + _test.go): no drift triggered. ✅
3. **Real service code change** (auth/main.go): STALE fires on auth.md as expected. ✅

## Test plan

- [x] `tools/drift-detector.sh 20` on main with fix: all OK
- [x] Pre-push hooks: `spec-drift`, `layer-check` pass
- [ ] CI green
- [ ] Rebase #649 and #650 onto the resulting main → drift check passes without workaround commits

## Closes

- Closes #657