### PR TITLE
fix(drift-detector): exclude */testdata/* from service-change detection

### DIFF
--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -74,6 +74,7 @@ CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '_test\.go$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v 'go\.mod$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v 'go\.sum$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/Dockerfile$' || true)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/testdata/' || true)
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "No changes detected in the last $COMMITS commits."
@@ -151,6 +152,7 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
           ':!*/MIGRATION.md' \
           ':!*/.layers' \
           ':!*_test.go' \
+          ':!*/testdata/*' \
           2>/dev/null)
         pattern_commit=${pattern_commit:-0}
         if [ "$pattern_commit" -gt "$service_last_commit" ]; then


### PR DESCRIPTION
## Summary

Testdata isn't service behavior — it's input to tests/validators. A change to `classifier/testdata/icp_labels.yml` changes what a validator measures; it doesn't change what the classifier service does. The current drift detector flags the service's spec STALE anyway. This fix excludes `*/testdata/*` at both detector call sites, mirroring the #657 pattern.

- CHANGED_FILES `grep -v` list: adds `/testdata/`
- `service_last_commit` pathspec: adds `:!*/testdata/*`

## Motivating case

Surfaced while landing #667's ICP labels scaffold (`classifier/testdata/icp_labels.yml` + `.schema.json`). Scaffold push was blocked because the detector flagged `docs/specs/classification.md` STALE even though no classifier service code changed.

## Watching brief

2nd occurrence of "drift detector treats supporting-file category as service behavior" (first was #657). If a 3rd category bites the detector, escalate to a systemic fix — allow-list or clearer "service behavior" definition at the detector level, rather than growing the deny-list further. Not acting on it yet; patching is correct for now.

## Test plan

- [x] `lefthook` pre-push: spec-drift + layer-check green on this branch
- [ ] CI green on PR
- [ ] After merge: rebase #667 scaffold branch onto main and confirm scaffold push succeeds

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)