### PR TITLE
chore(classifier): scaffold ICP labels schema + 3-doc pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ minoo-snapshot.md
 .firecrawl/
 
 .worktrees/
+
+# Pilot-labelling scratch — methodology distills to `icp_labels.yml` §Methodology
+# after first 20 labels; do not commit. See `docs/prospect-engine-plan.md` Appendix C.
+classifier/testdata/icp_labelling_log.md

--- a/classifier/testdata/icp-pilot-status.md
+++ b/classifier/testdata/icp-pilot-status.md
@@ -1,0 +1,278 @@
+# ICP Pilot-Labelling Status (issue #667)
+
+**Purpose.** Durable roadmap for the 53-doc ICP ternary-label pilot. Any Claude Code
+session (or human labeller) can resume from this file — it captures what's locked,
+what's done, what's in flight, and what's blocking progress.
+
+**Branch.** `claude/wave2-icp-labels-scaffold-667`
+**Spec.** `docs/prospect-engine-plan.md` Appendix C; amendment landed via #672.
+**Schema.** `classifier/testdata/icp_labels.schema.json` (ternary: strong/partial/none)
+**Labels artifact.** `classifier/testdata/icp_labels.yml`
+**Scratch log.** `classifier/testdata/icp_labelling_log.md` (gitignored — distills into
+`icp_labels.yml` §Methodology at doc-20 checkpoint)
+
+---
+
+## 1. Composition (LOCKED — do not redraw)
+
+53 docs across three segments + two none-buckets:
+
+| Stratum | Count | Breakdown |
+|---|---|---|
+| `indigenous_channel=strong` | 15 | 6 static org pages + 6 news articles + 3 press releases, pan-Canadian |
+| `northern_ontario_industry=strong` | 15 | 7 mining + 3 forestry + 2 energy/industry (OPG hydro, ON Northland) + 3 [re-evaluate at doc 20, see gap #NOI-breakdown] |
+| `private_sector_smb=strong` | 10 | 6 `obj_ca` diversified firm-types + 3 `financialpost_com` mid-market M&A + 1 [filler TBD] |
+| adjacency-none | 8 | 2 AU/NZ Indigenous + 2 southern-Ontario industry + 2 large-cap Canadian + 2 misc |
+| true none/none/none | 5 | weather, sports, international politics, lifestyle, entertainment |
+
+Downsize/upsize rationale (recorded in `icp_labelling_log.md`):
+- SMB downsized from 15 → 10 because of corpus scarcity (obj_ca has only 6 docs in
+  the entire ES corpus; 1 already used in batch 1 → 5 remain). Non-news prospecting
+  channels (LinkedIn, CCAB directory, RFP portals once MERX/Biddingo land) are the
+  right remedy — filed as open question in `docs/prospect-engine-plan.md` Appendix
+  §Open: corpus coverage for segments with low news density.
+- Adjacency-none upsized from 5 → 8 to give AU/NZ Indigenous + southern-Ontario
+  industry + large-cap Canadian each a dedicated forcing slot.
+
+---
+
+## 2. Methodology rules captured so far
+
+These recur across batches. Distilled into `icp_labels.yml` §Methodology at doc-20
+checkpoint.
+
+1. **Subject-of-story vs object-of-commentary (NOI).** For
+   `northern_ontario_industry=strong`, the mining/forestry/energy entity must be the
+   story's subject — not the object of commentary from outside the segment. Indigenous
+   policy statements about mining are subject=Indigenous entity, object=mining; they
+   fire `indigenous_channel=strong`, NOT NOI. (Batch 1 Doc 2 Anishinabek.)
+2. **Corridor-broadly interpretation (NOI geography).** NE/NW Ontario includes
+   Sault Ste Marie (Tenaris), Sudbury (Vale), Red Lake (Kinross Great Bear), Timmins
+   (gold belt), Kapuskasing/Hearst (forestry), Moosonee (ON Northland), Pickle Lake.
+   BC/AB mining = `none`, not `partial`. (Batch 1 Doc 8 Copper Mountain forcing
+   function.)
+3. **Adjacency ≠ partial.** If a doc is *adjacent to* the segment but outside v1
+   definition (seeded SaaS vs bootstrapped SMB, Canadian-mining-but-wrong-geography,
+   multinational-in-Canada vs mid-market), label `none` with notes explaining the
+   adjacency. `partial` is reserved for in-segment weak signals only. (Pre-batch Doc 3
+   Lumen.io relabel.)
+4. **Indigenous-channel pan-Canadian scope.** `indigenous_channel=strong` is not
+   corridor-scoped. ITK (national), MKO (Manitoba), Treaty #3 (NW Ontario),
+   Anishinabek (Ontario political union), IndigiNews (BC), APTN (national), Turtle
+   Island News (Ontario). Geographic restriction here starves the positives.
+5. **AU/NZ Indigenous → adjacency-none.** `indigenous_channel` is Canadian by
+   definition in v1. AU (ABC Indigenous, ATSIC), NZ (Waatea) content is
+   adjacency-none even when `topics=indigenous` fires. This is why the `topics`
+   field is NOT geographically anchored and sector_alignment will need Canadian
+   place/institution anchoring (cross-references #668).
+
+---
+
+## 3. Batch 1 — DONE
+
+10 docs labelled in `icp_labels.yml` (entries after the 3 schema examples).
+
+| # | doc_id | Stratum | Source | Title (abbrev) |
+|---|---|---|---|---|
+| 1 | `b56d3baa…444414bb9c55` | indigenous_channel=strong (page) | mkonation_com | MKO letter to AFN National Chief |
+| 2 | `69323ad8…36ff0b834` | indigenous_channel=strong (article) | Turtle Island News | Anishinabek Nation mining commentary |
+| 3 | `8628d923…30d0637a5b516fee` | indigenous_channel=strong (PR) | kenoraminerandnews_com | Grand Council Treaty #3 advisory |
+| 4 | `3189253d…a6dfa825bcb1` | NOI=strong (mining) | financialpost_com | Vale nickel asset divestiture (Sudbury) |
+| 5 | `30f502e0…f52d1e569b50af` | NOI=strong (mining) | financialpost_com | Kinross Great Bear permit (Red Lake) |
+| 6 | `e5e5f253…649bb351c7f740` | NOI=strong (energy/industry) | www_elliotlaketoday_com | Tenaris SSM 25-year anniversary |
+| 7 | `f99ed78f…92888b2e7983bd096be` | SMB=strong | obj_ca | Brazeau Seller Law — Marcogliese promotion |
+| 8 | `871a9bdd…1f0251b8d050` | adjacency-none (NOI geography) | mapleridgenews_com | Copper Mountain BC permit |
+| 9 | `2cea69bd…229b18ae3` | adjacency-none (triple-boundary) | www_bramptonguardian_com | Brampton Coca-Cola expansion |
+| 10 | `8591cd2d…e0fbce9125` | true none/none/none | Global News | Spring weather feature |
+
+Last `labelled_at: 2026-04-19T15:00:00Z`. All 10 have full `notes` + `labeller_confidence`;
+Doc 8 explicitly `low` confidence (partial-vs-none forcing function).
+
+---
+
+## 4. Batch 2 — IN FLIGHT (43 docs, drawn but not yet labelled)
+
+### 4a. Stratum composition + draw queries
+
+Per-stratum draw queries are pre-specified so the exact doc_ids can be regenerated
+deterministically via `mcp__North_Cloud__Production___search_content`. This is the
+unblocking path if the doc_id list below drifts.
+
+#### indigenous_channel=strong (12 docs — adds to 3 already labelled = 15)
+
+Target mix: 5 static org pages + 5 news articles + 2 press releases.
+
+Draw queries (pan-Canadian, segment entity as subject):
+- `source_name:apnonline_ca OR source_name:nctr_ca OR source_name:itk_ca OR source_name:indiginews_com` (homepages + articles)
+- `source_name:mkonation_com OR source_name:anishinabek_ca OR source_name:sco_ca` (org pages not yet used)
+- Articles: `topics:indigenous AND (title:"First Nation" OR title:"Métis" OR title:"Inuit") AND geography:Canada`
+- Press releases: Treaty orgs, NAN, Grand Council govt advisories
+
+Explicit exclusions: AU/NZ content (→ adjacency stratum), NCTR noisy-topic-tags
+(#668 dependency).
+
+#### northern_ontario_industry=strong (12 docs — adds to 3 already labelled = 15)
+
+Target mix: 7 mining + 3 forestry + 2 energy/industry. See gap #NOI-breakdown for
+7-mining slot allocation.
+
+Draw queries:
+- Mining: `content_type:article AND (title:"Kinross" OR title:"Glencore" OR title:"Vale" OR title:"Newmont Porcupine" OR title:"IAMGOLD Côté" OR title:"Alamos Young-Davidson" OR title:"New Gold Rainy River") AND geography:"Northern Ontario"`
+- Forestry: `title:("Resolute" OR "Domtar" OR "GreenFirst" OR "Kapuskasing" OR "Hearst sawmill") AND geography:"Northern Ontario"`
+- Energy/industry: `(title:"OPG" AND title:"hydro") OR title:"Ontario Northland" OR title:"Hydro One transmission"` (corridor)
+
+Explicit exclusions: southern-Ontario operators (→ adjacency), policy commentary
+about mining (→ indigenous_channel or none per subject-vs-object rule).
+
+#### private_sector_smb=strong (9 docs — adds to 1 already labelled = 10)
+
+Target mix: 6 `obj_ca` diversified firm-types (→ see gap #SMB-obj-ca-scarcity) + 3
+`financialpost_com` mid-market M&A.
+
+Draw queries:
+- obj_ca: `source_name:obj_ca` paginated walk (total corpus = 6 docs; 1 used; only
+  5 remain — scarcity gap, see §5)
+- FP mid-market M&A: `source_name:financialpost_com AND (title:"acquired" OR title:"acquires" OR title:"acquisition") AND NOT (title:"Vale" OR title:"Kinross" OR title:"Glencore")` (exclude already-labelled mining)
+
+Diversity target across the 9: at least one each of (law, manufacturing, tech
+services, family-owned, professional services, mid-market M&A).
+
+#### adjacency-none (6 docs — adds to 2 already labelled = 8)
+
+Target mix: 2 AU/NZ Indigenous + 2 southern-Ontario industry + 2 large-cap Canadian.
+
+Draw queries:
+- AU/NZ: `(source_name:*australia* OR source_name:*.nz OR source_name:waateanews*) AND topics:indigenous` (Mount Todd, Cadia, Waatea picks)
+- Southern Ontario industry: `geography:"Southern Ontario" AND topics:(manufacturing OR mining OR industry)` (Nestle London, auto parts, GTA food/bev)
+- Large-cap Canadian: `source_name:financialpost_com AND (title:"RBC" OR title:"Bank of Montreal" OR title:"CN Rail" OR title:"Enbridge") AND topics:(finance OR energy)` — tests "Canadian large-cap ≠ SMB"
+
+#### true none/none/none (4 docs — adds to 1 already labelled = 5)
+
+Target mix: 1 sports + 1 international politics + 1 lifestyle/recipe + 1 entertainment.
+
+Draw queries:
+- Sports: `topics:sports AND NOT topics:(indigenous OR mining)` (Crosby/hockey clean)
+- International: `geography:(Europe OR Asia) AND topics:politics` (Orban, Barcelona protests, EU)
+- Lifestyle: `topics:recipe OR topics:food_lifestyle`
+- Entertainment: `topics:entertainment AND NOT topics:indigenous`
+
+### 4b. Candidates draft state
+
+The draw executed during the prior session surfaced specific candidate doc_ids for
+all 43 slots (verified against ES). **They were not captured in a persisted file
+before the session compacted.** Rather than relist potentially-stale IDs from memory,
+the recovery path is:
+
+1. Re-run the draw queries in §4a using
+   `mcp__North_Cloud__Production___search_content`.
+2. Apply exclusions (doc_ids already in batch 1; noisy-topics docs per #668).
+3. Surface the resulting 43-slate as a new table (mirror structure of
+   `/tmp/first-10-candidates.md`) for user sign-off BEFORE labelling begins.
+
+This is the correct pattern regardless — the user's standing rule is "surface the
+full 43 candidates for sign-off before labels are applied." The redraw is cheap
+(one parallel-search call) and re-establishes ground truth.
+
+---
+
+## 5. Gap log (explicit open items)
+
+### Gap #SMB-obj-ca-scarcity — BLOCKING composition
+
+**Problem.** `source_name:obj_ca` facet count in the whole ES `classified_content`
+index = 6 docs. Batch 1 used 1 (Brazeau Seller). Only 5 obj_ca docs remain vs. the
+6-slot target. Cannot satisfy the composition from corpus.
+
+**Options:**
+- (a) Accept 5 obj_ca, backfill the 6th SMB slot with a second FP mid-market pick
+  (total SMB becomes 5 obj_ca + 4 FP).
+- (b) Accept 5 obj_ca, backfill with a trade-press SMB pick (e.g. Northern Ontario
+  Business profile of a corridor SMB — crosses into NOI territory, muddies label).
+- (c) Backfill with a LinkedIn/CCAB/RFP source if available in corpus (unlikely —
+  none of these are ingested yet).
+- (d) Drop SMB to 9 total, net composition 52 not 53.
+
+**Recommended.** (a) — preserves firm-type diversity source (FP = M&A stories), keeps
+label cleanness, and the 1-doc gap is inside the noise floor for v1 validator
+coverage targets.
+
+**Decision required from user.**
+
+### Gap #NOI-breakdown — needs draw execution
+
+**Problem.** The 7-mining slot in NOI=strong was specified only to
+Vale/Kinross-level. Need 5 more specific corridor-mining operators.
+
+**Candidates queued (from draw queries in §4a):**
+- Glencore Sudbury (nickel, smelter expansion)
+- Newmont Porcupine (Timmins gold)
+- IAMGOLD Côté (Gogama gold, recent)
+- Alamos Young-Davidson (Matachewan gold)
+- New Gold Rainy River (NW Ontario gold, near Fort Frances)
+- Pan American Silver / Wesdome (backup)
+
+Resolve: run the mining draw query, take top-5 excluding Vale/Kinross already used.
+
+### Gap #NOI-forestry — needs draw execution
+
+**Problem.** 3 forestry slots. Hearst/Kapuskasing and Thunder Bay forestry operators
+were not confirmed via top-5 ranking on prior draw.
+
+**Candidates queued:**
+- Resolute Forest Products (Thunder Bay pulp/paper)
+- GreenFirst Forest Products (Kapuskasing sawmill)
+- Domtar (Espanola)
+
+Resolve: run the forestry draw query in §4a.
+
+### Gap #NOI-energy-industry — decision recorded
+
+Per prior methodology discussion: "energy/industry 2" slot = OPG hydro (corridor
+stations — Umbata Falls, Rat Rapids, Kapuskasing) + ON Northland rail/transit.
+Tenaris SSM already in batch 1. Opportunistic multi-label if a First Nation JV or
+IBA-signatory story surfaces.
+
+### Gap #batch-2-draft-persisted — RESOLVED-BY-THIS-FILE
+
+The 43-candidate draft table is the artifact that goes stale fastest. The mitigation
+is §4a (draw queries pre-specified) + the §4b instruction to redraw cheaply on
+pickup. This file IS the persisted state; a per-doc table is regeneratable and
+shouldn't block progress.
+
+---
+
+## 6. Current gate
+
+**Awaiting.** User sign-off on:
+1. SMB scarcity decision (§5 Gap #SMB-obj-ca-scarcity — recommend option (a)).
+2. Batch 2 43-slate (to be re-surfaced via §4b redraw) before labels are applied.
+
+**Not blocked on.** Schema (#672 merged), plan amendment (#672 merged), Wave 2 CI
+validator (#669 — parallel track), noisy-topic-tags issue (#668 — parallel,
+doesn't invalidate v1 labels).
+
+---
+
+## 7. Resumable next-step directive
+
+For future-Claude (or future-human) picking up this work:
+
+1. **Read this file + `icp_labels.yml` + `icp_labelling_log.md`** (last is gitignored).
+2. **Check issue #667** for user response to the SMB scarcity question.
+3. **Re-run the 43-slate draw** per §4a queries. Surface as a new table for sign-off.
+4. **On sign-off**, label docs 11–53 in `icp_labels.yml` in 10-doc batches. After
+   each batch, surface the batch for review.
+5. **At doc 20**: methodology distillation checkpoint. Compress
+   `icp_labelling_log.md` rules into `icp_labels.yml` §Methodology (top of file).
+   Do NOT defer past doc 20.
+6. **At doc 53**: final review + prep for #669 Wave 2 validator consumption.
+
+Cross-refs: #667 (parent), #668 (ES mapping + duplicate-doc_id validator —
+parallel), #669 (sector_alignment validator — consumes this labels file), #672
+(schema + plan amendment, merged).
+
+---
+
+*Last updated 2026-04-19 by Claude during session continuation after context
+compaction. Prior work: batch 1 labelled, schema merged (#672), plan amended,
+composition locked at 12/12/9/6/4 for batch 2.*

--- a/classifier/testdata/icp-pilot-status.md
+++ b/classifier/testdata/icp-pilot-status.md
@@ -94,67 +94,28 @@ Doc 8 explicitly `low` confidence (partial-vs-none forcing function).
 
 ### 4a. Stratum composition + draw queries
 
-Per-stratum draw queries are pre-specified so the exact doc_ids can be regenerated
-deterministically via `mcp__North_Cloud__Production___search_content`. This is the
-unblocking path if the doc_id list below drifts.
+**Sourcing mechanism (amended 2026-04-19).** Batch sourcing runs against the MCP
+`search_content` tool from within a labelling session. The tool does full-text
+search with topic and content-type filters. It does not honour lucene
+`source_name:` filters or boolean NOT. Queries are therefore specified as
+single-topic or single-term bodies with a small `page_size` (start at 25), and
+source filtering happens client-side against the returned facets.
 
-#### indigenous_channel=strong (12 docs — adds to 3 already labelled = 15)
+Working pool size per query is capped so a response fits under ~20KB. A query
+that returns a 50KB+ pool is re-scoped, not truncated.
 
-Target mix: 5 static org pages + 5 news articles + 2 press releases.
+Source allow-lists by stratum:
 
-Draw queries (pan-Canadian, segment entity as subject):
-- `source_name:apnonline_ca OR source_name:nctr_ca OR source_name:itk_ca OR source_name:indiginews_com` (homepages + articles)
-- `source_name:mkonation_com OR source_name:anishinabek_ca OR source_name:sco_ca` (org pages not yet used)
-- Articles: `topics:indigenous AND (title:"First Nation" OR title:"Métis" OR title:"Inuit") AND geography:Canada`
-- Press releases: Treaty orgs, NAN, Grand Council govt advisories
+- Corridor mining: `www_timminspress_com`, `www_thesudburystar_com`,
+  `financialpost_com`, `www_elliotlaketoday_com`.
+- Corridor forestry, NE Ontario: `www_myespanolanow_com`, `www_sudbury_com`.
+- AU/NZ Indigenous adjacency: ABC Indigenous, Asia Pacific Report.
 
-Explicit exclusions: AU/NZ content (→ adjacency stratum), NCTR noisy-topic-tags
-(#668 dependency).
+Excluded for corridor-intent queries: `www_argusmedia_com` (global trade-press),
+Ahead of the Herd (BC adjacency).
 
-#### northern_ontario_industry=strong (12 docs — adds to 3 already labelled = 15)
-
-Target mix: 7 mining + 3 forestry + 2 energy/industry. See gap #NOI-breakdown for
-7-mining slot allocation.
-
-Draw queries:
-- Mining: `content_type:article AND (title:"Kinross" OR title:"Glencore" OR title:"Vale" OR title:"Newmont Porcupine" OR title:"IAMGOLD Côté" OR title:"Alamos Young-Davidson" OR title:"New Gold Rainy River") AND geography:"Northern Ontario"`
-- Forestry: `title:("Resolute" OR "Domtar" OR "GreenFirst" OR "Kapuskasing" OR "Hearst sawmill") AND geography:"Northern Ontario"`
-- Energy/industry: `(title:"OPG" AND title:"hydro") OR title:"Ontario Northland" OR title:"Hydro One transmission"` (corridor)
-
-Explicit exclusions: southern-Ontario operators (→ adjacency), policy commentary
-about mining (→ indigenous_channel or none per subject-vs-object rule).
-
-#### private_sector_smb=strong (9 docs — adds to 1 already labelled = 10)
-
-Target mix: 6 `obj_ca` diversified firm-types (→ see gap #SMB-obj-ca-scarcity) + 3
-`financialpost_com` mid-market M&A.
-
-Draw queries:
-- obj_ca: `source_name:obj_ca` paginated walk (total corpus = 6 docs; 1 used; only
-  5 remain — scarcity gap, see §5)
-- FP mid-market M&A: `source_name:financialpost_com AND (title:"acquired" OR title:"acquires" OR title:"acquisition") AND NOT (title:"Vale" OR title:"Kinross" OR title:"Glencore")` (exclude already-labelled mining)
-
-Diversity target across the 9: at least one each of (law, manufacturing, tech
-services, family-owned, professional services, mid-market M&A).
-
-#### adjacency-none (6 docs — adds to 2 already labelled = 8)
-
-Target mix: 2 AU/NZ Indigenous + 2 southern-Ontario industry + 2 large-cap Canadian.
-
-Draw queries:
-- AU/NZ: `(source_name:*australia* OR source_name:*.nz OR source_name:waateanews*) AND topics:indigenous` (Mount Todd, Cadia, Waatea picks)
-- Southern Ontario industry: `geography:"Southern Ontario" AND topics:(manufacturing OR mining OR industry)` (Nestle London, auto parts, GTA food/bev)
-- Large-cap Canadian: `source_name:financialpost_com AND (title:"RBC" OR title:"Bank of Montreal" OR title:"CN Rail" OR title:"Enbridge") AND topics:(finance OR energy)` — tests "Canadian large-cap ≠ SMB"
-
-#### true none/none/none (4 docs — adds to 1 already labelled = 5)
-
-Target mix: 1 sports + 1 international politics + 1 lifestyle/recipe + 1 entertainment.
-
-Draw queries:
-- Sports: `topics:sports AND NOT topics:(indigenous OR mining)` (Crosby/hockey clean)
-- International: `geography:(Europe OR Asia) AND topics:politics` (Orban, Barcelona protests, EU)
-- Lifestyle: `topics:recipe OR topics:food_lifestyle`
-- Entertainment: `topics:entertainment AND NOT topics:indigenous`
+Lucene examples in other sections remain valid for direct-ES sessions. They are
+not the labelling-session spec.
 
 ### 4b. Candidates draft state
 

--- a/classifier/testdata/icp-pilot-status.md
+++ b/classifier/testdata/icp-pilot-status.md
@@ -141,8 +141,9 @@ full 43 candidates for sign-off before labels are applied." The redraw is cheap
 ### Gap #SMB-obj-ca-scarcity — BLOCKING composition
 
 **Problem.** `source_name:obj_ca` facet count in the whole ES `classified_content`
-index = 6 docs. Batch 1 used 1 (Brazeau Seller). Only 5 obj_ca docs remain vs. the
-6-slot target. Cannot satisfy the composition from corpus.
+index = 6 docs. Batch 1 used 1 (Brazeau Seller / `f99ed78f` / `obj_ca` /
+`smb=strong`). Only 5 obj_ca docs remain vs. the 6-slot target. Cannot satisfy
+the composition from corpus.
 
 **Options:**
 - (a) Accept 5 obj_ca, backfill the 6th SMB slot with a second FP mid-market pick

--- a/classifier/testdata/icp_labels.schema.json
+++ b/classifier/testdata/icp_labels.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ICP labels — sector_alignment ground truth",
+  "type": "object",
+  "required": ["segment_schema_version", "segments", "labels"],
+  "additionalProperties": false,
+  "properties": {
+    "segment_schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Matches the version of source-manager/data/icp-segments.yml. Bump triggers re-confirmation of label semantics."
+    },
+    "segments": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": { "enum": ["indigenous_channel", "northern_ontario_industry", "private_sector_smb"] }
+    },
+    "labels": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/label" }
+    }
+  },
+  "$defs": {
+    "label": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "doc_id", "es_index", "ingest_timestamp",
+        "title", "excerpt",
+        "segments", "labeller_confidence",
+        "labeller", "labelled_at"
+      ],
+      "properties": {
+        "doc_id":           { "type": "string", "minLength": 1 },
+        "es_index":         { "type": "string", "minLength": 1 },
+        "ingest_timestamp": { "type": "string", "format": "date-time" },
+        "title":            { "type": "string", "minLength": 1 },
+        "excerpt":          { "type": "string", "minLength": 1 },
+        "segments": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["indigenous_channel", "northern_ontario_industry", "private_sector_smb"],
+          "properties": {
+            "indigenous_channel":        { "enum": ["strong", "partial", "none"] },
+            "northern_ontario_industry": { "enum": ["strong", "partial", "none"] },
+            "private_sector_smb":        { "enum": ["strong", "partial", "none"] }
+          }
+        },
+        "labeller_confidence": { "enum": ["high", "medium", "low"] },
+        "labeller":            { "type": "string", "minLength": 1 },
+        "labelled_at":         { "type": "string", "format": "date-time" },
+        "notes":               { "type": "string" }
+      }
+    }
+  }
+}

--- a/classifier/testdata/icp_labels.yml
+++ b/classifier/testdata/icp_labels.yml
@@ -82,3 +82,223 @@ labels:
       mid-size criteria. Adjacent to segment via SaaS/tech framing but outside the
       current definition. Candidate for segment expansion discussion, not for partial
       credit against v1 definition.
+
+  # ---------------------------------------------------------------------------
+  # Batch 1 (2026-04-19 pilot, first-10 draw — issue #667).
+  # Methodology, stratum sourcing, and drift notes live in
+  # `classifier/testdata/icp_labelling_log.md` (gitignored scratch).
+  #
+  # `ingest_timestamp` is the ES `crawled_at` value from classified_content
+  # (point at which the classifier ingested the source doc). Refreshed inline
+  # from the production index at labelling time — not a validator-gated deferral.
+  # ---------------------------------------------------------------------------
+
+  - doc_id: "b56d3baa9d337e0215d3ad29e61d0512c2e21d361aa03d0c0390444414bb9c55"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-24T04:39:06.047028148Z
+    title: "Congratulations to newly elected AFN National Chief RoseAnne Archibald * Manitoba Keewatinowi Okimakanak"
+    excerpt: >-
+      Manitoba Keewatinowi Okimakanak (MKO) governance correspondence published on
+      mkonation_com — an organizational letter from MKO to newly elected AFN
+      National Chief RoseAnne Archibald. Channel content on an Indigenous
+      Political Territorial Organization's own domain.
+    segments:
+      indigenous_channel: strong
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Pan-Canadian confirmation case: MKO is Manitoba, not Ontario. `indigenous_channel`
+      scope is pan-Canadian per segment definition — segment 1 scope ≠ NE/NW Ontario
+      outreach corridor scope (that is segment 2's anchor). See labelling log
+      §"Geographic scope — pan-Canadian confirmation cases".
+
+  - doc_id: "69323ad854f95b32cc13702614183523a818c408fd6ea52e5fc099436ff0b834"
+    es_index: classified_content
+    ingest_timestamp: 2026-04-16T17:38:12.20582777Z
+    title: "Anishinabek Nation warns mining industry: certainty requires partnership with First Nations - The Turtle Island News"
+    excerpt: >-
+      Anishinabek Nation (Ontario First Nations political union) statement calling on
+      the mining sector to partner with First Nations for regulatory certainty.
+      Published by Turtle Island News. Canadian-anchored, NE/NW Ontario corridor-adjacent.
+    segments:
+      indigenous_channel: strong
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: medium
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Multi-label candidate examined and rejected on close read. The piece is
+      Indigenous-governance policy commentary *about* the mining sector — not an
+      operator-centric mining story. Per labelling log §"Multi-label discipline",
+      don't force multi-label when the multi-segment surface dissolves on inspection.
+      NOI is `none` with the adjacency documented here, not rewarded with `partial`.
+      Confidence `medium` because the mining framing is prominent enough that a
+      future labeller might reasonably reach a different call.
+
+  - doc_id: "8628d92396bdb32a92c02d92f69f66a761e1dd810f21517030d0637a5b516fee"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-08T00:36:30.983481702Z
+    title: "'Rights must be respected': Grand Council Treaty #3 warns about travel to the United States"
+    excerpt: >-
+      Treaty #3 (NW Ontario / Manitoba border) governance advisory, press-release-shaped.
+      Published via kenoraminerandnews_com (non-Indigenous outlet carrying the Indigenous
+      governing body's notice verbatim).
+    segments:
+      indigenous_channel: strong
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Channel signal is the issuing entity (Treaty #3), not the outlet. Non-Indigenous
+      outlet carrying Indigenous governance content still counts as `indigenous_channel=strong`.
+
+  - doc_id: "3189253d0f8427d08ae3e133a3dab6241f2c4ba15d9e9e882f52a6dfa825bcb1"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-23T16:16:23.094029796Z
+    title: "Vale to yield control of nickel assets in Canada"
+    excerpt: >-
+      Vale Sudbury (Copper Cliff) nickel asset divestiture — NE Ontario mining major
+      restructuring covered by Financial Post.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: strong
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Canonical NE Ontario mining-major operator story. SMB is `none` (not partial)
+      per existing precedent (cc_20260315_vale_thunderbay_smelter) — multinational
+      subsidiary ≠ SMB-sized.
+
+  - doc_id: "30f502e02de69f631eadd2f192e42d872cc8edae81fb405e56f52d1e569b50af"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-18T16:24:05.163448466Z
+    title: "Ontario designates Kinross Gold's Great Bear project for speedy permit approval"
+    excerpt: >-
+      Kinross Great Bear gold project (NW Ontario, near Red Lake) permit acceleration —
+      corridor-anchored mining project, Financial Post coverage.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: strong
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Canonical NW Ontario mining project. Red Lake geographic anchor is the corridor;
+      Kinross is the operator. Straightforward NOI=strong.
+
+  - doc_id: "e5e5f253bde673ff7574544fd8e19c9093d03b174ab957b04d649bb351c7f740"
+    es_index: classified_content
+    ingest_timestamp: 2026-01-01T21:47:05Z
+    title: "Twenty-five years in the Sault, Tenaris eyes growth as Canada boosts energy ambitions"
+    excerpt: >-
+      Tenaris Canadian Industrial Centre in Sault Ste. Marie — seamless steel pipe and
+      ERW manufacturing, 25-year corridor operation. Published by Elliot Lake Today
+      (NE Ontario outlet).
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: strong
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Energy/industry sub-bucket anchor for NE Ontario. SSM industrial manufacturer
+      with 25-year corridor tenure. Clean NOI=strong; source is an NE Ontario outlet
+      so no outlet-framing risk. (Swapped in from earlier Ford-rail/Western-Standard
+      candidate — see labelling log and candidates file for rationale.)
+
+  - doc_id: "f99ed78fbea26f560ce16a53edfa82b09d480b47d3d3292888b2e7983bd096be"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-21T12:22:59.387058054Z
+    title: "Michael Marcogliese"
+    excerpt: >-
+      Ottawa mid-market law firm (Brazeau Seller Law) announces partner promotion.
+      Published by Ottawa Business Journal (obj_ca). Canonical obj_ca professional-services
+      SMB content shape.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: none
+      private_sector_smb: strong
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      First-10 SMB slot (downsized from 2 to 1 — firm-type diversity is a batch-level
+      rule across the 7 obj_ca in the full 53-doc batch, not a first-10 constraint).
+      Remaining 6 SMB slots in batch 2 will add manufacturing, tech mid-market, and
+      family-owned shapes per labelling log §"private_sector_smb firm-type diversity".
+
+  - doc_id: "871a9bddc59ee662ab98ddcafe65a7005577ad3fc67e9c6e9b4d1f0251b8d050"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-22T16:50:19Z
+    title: "Province issues accelerated permit to expand Similkameen Valley's Copper Mountain Mine"
+    excerpt: >-
+      Hudbay-owned Copper Mountain copper mine in BC's Similkameen Valley — accelerated
+      provincial permit for expansion. Canadian mining operator, BC not NE/NW Ontario.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Partial-vs-none forcing function for NOI. Confidence is `high` because the
+      label application is firm under the current schema: the header comment
+      explicitly states "adjacency is documented in notes, not rewarded with
+      partial credit," so Canadian-mining-but-wrong-geography earns `none`, not
+      `partial`. The *rule* is under review (see labelling log §"Open questions"),
+      not this specific label. Pending rule review ≠ pending label uncertainty.
+      If the rule is revised in batch 2 to admit industry-only partials, this
+      label is a first candidate for re-examination; until then, the rule-as-
+      written produces `none` with confidence.
+
+  - doc_id: "2cea69bdb407039f0d0e1a65f1ed2d6d9cf855d723877196c4d4532229b18ae3"
+    es_index: classified_content
+    ingest_timestamp: 2026-02-20T17:37:22Z
+    title: "Brampton Coca-Cola bottling plant announces $141M expansion"
+    excerpt: >-
+      Coca-Cola (US multinational) CPG bottling expansion in Brampton (GTA, southern
+      Ontario). Published by Brampton Guardian. Teaches three adjacency-none boundaries
+      at once.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Triple adjacency-none — multinational-in-Canada ≠ SMB, southern Ontario ≠ NOI
+      corridor, CPG ≠ target NOI industry (mining/forestry/energy/municipalities).
+      Canonical multinational-outside-industry-AND-geography teaching signal per
+      labelling log §"Adjacency-none discipline".
+
+  - doc_id: "8591cd2d95743355817e47fb7882b0b9721af6129e38044af44e0fef0bce9125"
+    es_index: classified_content
+    ingest_timestamp: 2026-03-20T20:04:58Z
+    title: "Spring is here, but forecasts say the temperature change will be 'slow'"
+    excerpt: >-
+      Generic Canadian weather feature from Global News — seasonal forecast explainer.
+      Classified topics confirmed strictly environment/weather, no mining/forestry/
+      Indigenous/SMB tangent.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      True none/none/none anchor for batch 1. Topic classification verified clean
+      (no segment-adjacent signal leakage). Canonical example of "structurally
+      unrelated to all three segments".

--- a/classifier/testdata/icp_labels.yml
+++ b/classifier/testdata/icp_labels.yml
@@ -1,0 +1,84 @@
+# ICP labels — ground truth for the sector_alignment validator (§3.5 of docs/prospect-engine-plan.md).
+# Validated in CI against classifier/testdata/icp_labels.schema.json (wiring tracked in #668).
+#
+# segment_schema_version tracks source-manager/data/icp-segments.yml. When segments are
+# renamed or retired via the Ownership flow (§3.4), bump both files together; existing
+# labels then need explicit re-confirmation before the validator treats them as ground truth.
+#
+# doc_id should be the ES _id from classified_content. The examples below use illustrative
+# slugs for readability; real entries use the ES-assigned ID.
+#
+# Ternary semantics (strong / partial / none):
+#   strong  — doc is a canonical fit for the segment
+#   partial — doc is a legitimate partial fit within the segment's definition
+#   none    — doc does not fit the segment (including "adjacent but outside" cases —
+#             adjacency is documented in notes, not rewarded with partial credit)
+
+segment_schema_version: 1
+segments:
+  - indigenous_channel
+  - northern_ontario_industry
+  - private_sector_smb
+
+labels:
+  - doc_id: "cc_20260312_sudbury_fn_water_infra"
+    es_index: classified_content
+    ingest_timestamp: 2026-03-12T14:22:00Z
+    title: "Nishnawbe Engineering wins $14M water-infrastructure contract for Wahnapitae First Nation"
+    excerpt: >-
+      Nishnawbe Engineering, a Sudbury-based Indigenous-owned consultancy, has been
+      selected by the Wahnapitae First Nation for a $14M potable-water upgrade. The
+      firm, founded in 2009, employs 45 engineers and consultants.
+    segments:
+      indigenous_channel: strong
+      northern_ontario_industry: partial
+      private_sector_smb: strong
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Multi-label strong on two segments — Indigenous ownership is clear, engineering
+      consultancy fits private_sector_smb. northern_ontario_industry is partial because
+      the Sudbury location hits, but the canonical segment targets mining/forestry/energy/
+      municipalities — engineering consulting for a First Nation is adjacent, not core.
+
+  - doc_id: "cc_20260315_vale_thunderbay_smelter"
+    es_index: classified_content
+    ingest_timestamp: 2026-03-15T09:05:00Z
+    title: "Vale Canada reports Q1 production increase at Thunder Bay nickel smelter"
+    excerpt: >-
+      Vale Canada's Thunder Bay smelter reported a 7% Q1 production increase, citing
+      upgraded furnace controls and an expanded workforce of 340. The Brazil-headquartered
+      multinational operates three Ontario facilities.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: strong
+      private_sector_smb: none
+    labeller_confidence: high
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Canonical northern_ontario_industry — mining in the Thunder Bay corridor.
+      private_sector_smb is none (not partial) because Vale Canada is a multinational
+      subsidiary, not SMB-sized. Calling it partial would dilute the signal.
+
+  - doc_id: "cc_20260328_toronto_saas_seed"
+    es_index: classified_content
+    ingest_timestamp: 2026-03-28T18:44:00Z
+    title: "Toronto SaaS startup Lumen.io closes $2M seed round"
+    excerpt: >-
+      Lumen.io, a Toronto-based bootstrapped SaaS firm building developer tooling for
+      database observability, has closed a $2M seed round led by Golden Ventures. The
+      four-person team plans to hire six more in 2026.
+    segments:
+      indigenous_channel: none
+      northern_ontario_industry: none
+      private_sector_smb: none
+    labeller_confidence: medium
+    labeller: jonesrussell
+    labelled_at: 2026-04-19T15:00:00Z
+    notes: >-
+      Seeded SaaS, four-person team. Does not match bootstrapped (now VC-funded) or
+      mid-size criteria. Adjacent to segment via SaaS/tech framing but outside the
+      current definition. Candidate for segment expansion discussion, not for partial
+      credit against v1 definition.


### PR DESCRIPTION
## Summary

Scaffold for the `sector_alignment` validator's ground-truth corpus (§3.5 of `docs/prospect-engine-plan.md`). Refs #667; does not close it — Russell extends the YAML from 3 to 50–100 entries in follow-up commits against the now-established shape.

- `classifier/testdata/icp_labels.schema.json` — JSON Schema, Draft 2020-12, strict (`additionalProperties: false` at every level)
- `classifier/testdata/icp_labels.yml` — three pilot entries spanning the interesting shapes

## Schema decisions (locked via Wave 2 amendment review)

- **Ternary per segment** (`strong` / `partial` / `none`), all three segments required per label + enum — ambiguity by omission is structurally impossible. No floats: human labellers produce noisy floats, and fake precision is worse than coarse precision.
- **Multi-label** via object map over the three seed segments.
- **`segment_schema_version: 1`** as a JSON Schema `const` — a seed YAML bump requires a coordinated schema bump, making silent drift impossible.
- **`labeller_confidence`** categorical (`high` / `medium` / `low`), not float — same reasoning as ternary.
- **Labeller provenance** (`labeller` + `labelled_at`) required per label — leaves room for a second pair of eyes later without migration.

## Three pilot entries deliberately span the interesting cases

1. Indigenous-owned engineering consultancy in Sudbury with a First Nation contract — multi-label `strong` × 2 + `partial`. Demonstrates that Sudbury location alone isn't a canonical fit for `northern_ontario_industry`.
2. Vale Thunder Bay smelter — canonical single-segment `strong`, firm `none` on the others ("calling it partial would dilute the signal").
3. Toronto SaaS startup (Lumen.io) — `none` on all three with notes explaining the adjacency. Resists the drift pattern where "adjacent to segment" bleeds into `partial`: if adjacency earned partial credit, the ternary would collapse and the validator's F1 metric would become meaningless.

## Deferred, tracked in #668

- Wire JSON Schema validation into CI for both `source-manager/data/icp-segments.yml` and `classifier/testdata/icp_labels.yml`.
- Supplementary script-level check for unique `doc_id` within `labels[]` (JSON Schema's `uniqueItems` can't enforce uniqueness on a single field within otherwise-differing objects).

## Test plan

- [x] `lefthook` pre-push: spec-drift + layer-check green (passes cleanly now that #671 landed — scaffold push was blocked by the drift detector's pre-fix behavior, tracked in #670)
- [ ] CI green on PR
- [ ] Schema validates the YAML locally (no CI wiring yet — will be covered by #668)
- [ ] Russell pilot-labels against the schema and opens a follow-up PR extending the YAML

Refs #667
Related: #670 (drift-detector testdata exclusion, just merged), #668 (CI wiring scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)