### PR TITLE
docs(workflow): add stacked-PR merge sequence (Rule 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ See `ARCHITECTURE.md` for the full bootstrap pattern reference.
 3. **Milestones have due dates** — stale milestones flagged by SessionStart hook
 4. **Conventional commits** — `type(scope): description` (feat/fix/chore/docs/refactor/test/ci/perf)
 5. **PR template enforces checklist** — issue ref, milestone, lint, tests, spec updates
+6. **Stacked PR merge sequence** — retarget dependents to `main` before merging the parent; see `docs/specs/workflow.md` Rule 6
 
 See `docs/specs/workflow.md` for full details. Governance hook: `bin/check-milestones`.
 

--- a/docs/specs/workflow.md
+++ b/docs/specs/workflow.md
@@ -34,6 +34,18 @@ Active milestones should have due dates set. The `bin/check-milestones` hook fla
 ### Rule 5: Commit Messages Follow Conventional Commits
 Format: `type(scope): description` where type is `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`. Scope is the service name or `deploy`/`context`/`deps` for cross-cutting changes.
 
+### Rule 6: Stacked PR Merge Sequence
+
+When a PR's base is another feature branch (not `main`), merging the parent does not auto-retarget dependent PRs. A dependent merged in that state squash-lands the commit onto the now-orphaned parent branch, so no Deploy workflow fires on `main`. The condition is recoverable via cherry-pick, but each occurrence costs an investigation and a re-landing PR.
+
+When follow-on edits are identified on an open PR, pick one of three paths:
+
+1. **Fold fixups into the open PR.** Best when the edit targets a file the parent PR is introducing. Push additional commits to the parent branch and leave a summary comment on the PR so reviewers know what the new commits contain.
+2. **Stack a dependent PR, retarget before the parent merges.** Appropriate when the edit does not belong in the parent. Before squash-merging the parent, run `gh pr edit <dep> --base main` on every dependent PR. Then merge the parent, then merge dependents.
+3. **Wait for the parent to merge, then branch from `main`.** Simplest sequence. Acceptable when the parent is imminent and the edit is not blocking.
+
+**Worked example (2026-04-19 / PR #672).** PR #672 was open when two follow-on edits were identified. The edits targeted the file #672 was introducing. The fixups were folded into #672 directly as additional commits on the scaffold branch. Stacking separate PRs on that branch would have walked into the retarget footgun the moment #672 squash-merged. Merge commit `cec65bea`.
+
 ## Governance Automation
 
 - **SessionStart hook**: Runs `bin/check-milestones` to surface untriaged issues and stale milestones


### PR DESCRIPTION
## Summary

- Adds Rule 6 to `docs/specs/workflow.md` codifying the retarget protocol from #662 (2026-04-18 trilogy incident)
- Lists three paths for follow-on edits on an open PR: fold into parent, stack + retarget before parent merges, or wait + branch from `main`
- Anchors with the 2026-04-19 / PR #672 case as worked example (merge commit `cec65bea`)
- One-line cross-reference added under `CLAUDE.md` git workflow rules

## Acceptance (from #662)

- [x] Protocol documented in `docs/specs/workflow.md` under a stacked-PR merge sequence section
- [x] `CLAUDE.md` references the protocol in the git workflow section
- [ ] Automated guard (marked optional in #662; not in this PR)

## Test plan

- [ ] CI green
- [ ] Reviewer check: the three-path decision tree captures the real options; the worked example reads unambiguously
- [ ] Reviewer check: adding automated enforcement later would not invalidate this rule text

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)