### PR TITLE
fix(drift-detector): exclude dependency lockfiles from service-change detection

### DIFF
--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -75,6 +75,10 @@ CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v 'go\.mod$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v 'go\.sum$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/Dockerfile$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/testdata/' || true)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/package-lock\.json$' || true)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/yarn\.lock$' || true)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/pnpm-lock\.yaml$' || true)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/composer\.lock$' || true)
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "No changes detected in the last $COMMITS commits."
@@ -153,6 +157,10 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
           ':!*/.layers' \
           ':!*_test.go' \
           ':!*/testdata/*' \
+          ':!*/package-lock.json' \
+          ':!*/yarn.lock' \
+          ':!*/pnpm-lock.yaml' \
+          ':!*/composer.lock' \
           2>/dev/null)
         pattern_commit=${pattern_commit:-0}
         if [ "$pattern_commit" -gt "$service_last_commit" ]; then


### PR DESCRIPTION
## Summary

Dependency lockfiles aren't service behavior — they're the compiled output of a package-manager solve. A `package-lock.json` bump from Dependabot doesn't change what the service does, but the current drift detector flags the service's spec STALE anyway. This fix excludes the four lockfile shapes this repo carries at both detector call sites, mirroring the #671 pattern.

- `CHANGED_FILES` grep -v list: adds `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `composer.lock`
- `service_last_commit` pathspec: same four paths

Note: `go.mod` and `go.sum` are already excluded at both sites (since #516), so no Go-side change needed.

## Motivating case

Surfaced while draining the Dependabot triage queue on 2026-04-20. Six PRs were stuck UNSTABLE with only a lockfile in the diff, all failing the Spec Drift Check:

| PR | Dep | Spec falsely flagged | Blocked via |
|---|---|---|---|
| #634 | follow-redirects /search-frontend | `search-frontend.md` | `search-frontend/package-lock.json` |
| #629 | axios /search-frontend | `search-frontend.md` | same |
| #619 | vite /search-frontend | `search-frontend.md` | same |
| #627 | axios /dashboard | `dashboard.md` | `dashboard/package-lock.json` |
| #620 | vite /dashboard | `dashboard.md` | same |
| #591 | defu /dashboard | `dashboard.md` | same |

## Scope check

The repo carries only four lockfile shapes (non-vendored):
- `package-lock.json` — `tools/spec-retrieval`, `dashboard-waaseyaa/frontend`, `dashboard`, `search-frontend`
- `composer.lock` — `dashboard-waaseyaa`, `data/communities`

`yarn.lock` and `pnpm-lock.yaml` aren't present today but are added defensively — same cost, future-proofs the exclusion if a service switches package manager.

## Watching brief

3rd occurrence of the "drift detector treats supporting-file category as service behavior" pattern (after #657 vendor/ and #671 testdata/). #671 flagged this as the escalation trigger — the rules for what counts as "service behavior" would benefit from an allow-list rewrite, not more deny-list entries. Not doing that now; patching is correct for this case. Flagging for the next session.

## Test plan

- [x] `bash -n tools/drift-detector.sh` — syntax clean
- [x] `bash tools/drift-detector.sh 20` on current main — all specs OK (no regression in normal path)
- [x] `lefthook` pre-push: spec-drift + layer-check green on this branch
- [ ] CI green on PR
- [ ] After merge: `@dependabot rebase` on the six blocked PRs — drift check should go green

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)