### PR TITLE
fix(crawler): defer WithTimeout cancel for gosec G118

### DIFF
--- a/crawler/internal/scheduler/scheduler_execution.go
+++ b/crawler/internal/scheduler/scheduler_execution.go
@@ -80,8 +80,12 @@ func (s *IntervalScheduler) executeJob(job *domain.Job) {
 
 	s.metrics.IncrementRunning()
 
-	// Execute in goroutine
-	go s.runJob(jobExec)
+	// Run in a goroutine; defer cancel releases the WithTimeout timer when runJob returns
+	// (idempotent if CancelJob or shutdown already called cancel).
+	go func() {
+		defer cancel()
+		s.runJob(jobExec)
+	}()
 }
 
 // writeLog writes a log entry if the log writer is available.

--- a/docs/specs/content-acquisition.md
+++ b/docs/specs/content-acquisition.md
@@ -1,6 +1,6 @@
 # Content Acquisition Specification
 
-> Last verified: 2026-03-22 (fix test lint: testpackage, nilnil)
+> Last verified: 2026-04-22 (crawler: defer WithTimeout cancel when job goroutine exits)
 
 Covers the crawler subsystem: web content fetching, job scheduling, frontier URL management, and raw content indexing.
 
@@ -13,6 +13,7 @@ Covers the crawler subsystem: web content fetching, job scheduling, frontier URL
 | `crawler/internal/crawler/crawler.go` | Core Crawler struct and CrawlerInterface |
 | `crawler/internal/crawler/factory.go` | Factory pattern for per-job isolation |
 | `crawler/internal/scheduler/interval_scheduler.go` | Interval-based job scheduler with CAS locking |
+| `crawler/internal/scheduler/scheduler_execution.go` | Per-job `runJob` goroutine; execution timeout context and cleanup |
 | `crawler/internal/scheduler/state_machine.go` | Job state transitions (pending→scheduled→running→completed/failed) |
 | `crawler/internal/fetcher/worker.go` | Frontier fetcher worker pool (lightweight URL fetching) |
 | `crawler/internal/storage/types/interface.go` | Storage + IndexManager interfaces |


### PR DESCRIPTION
## Summary
- **G118**: `context.WithTimeout` in `executeJob` stored `cancel` on `JobExecution` but never invoked it in the lexical scope where gosec runs, and `runJob` did not defer it on normal completion. The timeout timer could linger until the deadline even after a job finished.
- **Fix**: Start the job in a small goroutine closure that `defer cancel()`s after `runJob` returns. `CancelJob` / scheduler shutdown still call the same `CancelFunc`; second calls are no-ops per `context` API.

## Validation
- `task crawler:lint` — pass (0 issues).

## Local `task ci` notes (this environment)
- **Dashboard**: `eslint` missing until `npm ci` in `dashboard/` (devdeps not installed on a bare clone).
- **source-manager**: `internal/repository` tests hit the default **600s** test timeout waiting on **Postgres** (`lib/pq` dial) — integration tests need a reachable DB; unrelated to this change.

CI on GitHub is the merge gate.

## Follow-up (not this PR)
- Other `context.WithTimeout` sites in crawler were skimmed; `worker.go` already uses `defer cancel()`. `internal_handler`, `streams`, `redis_buffer`, `producer` may warrant a separate gosec sweep if not already clean.

Made with [Cursor](https://cursor.com)