### PR TITLE
[codex] fix drift detector for package manifest bumps

### DIFF
--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -75,6 +75,7 @@ CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v 'go\.mod$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v 'go\.sum$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/Dockerfile$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/testdata/' || true)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/package\.json$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/package-lock\.json$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/yarn\.lock$' || true)
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '/pnpm-lock\.yaml$' || true)
@@ -163,6 +164,7 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
           ':!*/.layers' \
           ':!*_test.go' \
           ':!*/testdata/*' \
+          ':!*/package.json' \
           ':!*/package-lock.json' \
           ':!*/yarn.lock' \
           ':!*/pnpm-lock.yaml' \


### PR DESCRIPTION
## Summary

- Exclude frontend `package.json` manifests from spec drift changed-file detection.
- Keep the service timestamp comparison exclusions aligned with the changed-file filter.

## Why

Dependabot frontend PRs that only bump dependencies were still touching `package.json`, so the drift detector treated dashboard/search-frontend specs as stale even though the dependency lockfiles were already ignored.

## Validation

- Ran `tools/drift-detector.sh 20` through a temporary LF-normalized copy on Windows; it passed and reported all affected specs up to date.
- Ran `git diff --check`.
