### PR TITLE
feat(validator): add sector_alignment coverage and accuracy gate

### DIFF
--- a/.github/workflows/validate-sector-alignment.yml
+++ b/.github/workflows/validate-sector-alignment.yml
@@ -1,0 +1,151 @@
+name: validate-sector-alignment
+
+on:
+  schedule:
+    # Daily at 14:20 UTC, after the org-attribution validation window.
+    - cron: '20 14 * * *'
+  workflow_dispatch:
+    inputs:
+      coverage_threshold:
+        description: 'Minimum icp.segments[] populated rate (0.0 - 1.0)'
+        required: false
+        # Initial permissive gate. Promote to 0.80+ after 14 consecutive clean
+        # --since 24h runs against production classified-content data.
+        default: '0.25'
+      accuracy_threshold:
+        description: 'Minimum held-out F1 per ICP segment (0.0 - 1.0)'
+        required: false
+        # Initial permissive gate. Promote to 0.70+ after 14 consecutive clean
+        # runs and review of private_sector_smb production coverage.
+        default: '0.25'
+      since:
+        description: 'RFC3339 timestamp or duration window for crawled_at (for example 24h)'
+        required: false
+        default: '24h'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-sector-alignment
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Check sector_alignment coverage and held-out accuracy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      COVERAGE_THRESHOLD_INPUT: ${{ inputs.coverage_threshold }}
+      ACCURACY_THRESHOLD_INPUT: ${{ inputs.accuracy_threshold }}
+      SINCE_INPUT: ${{ inputs.since }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Build validator
+        working-directory: tools/validate-sector-alignment
+        run: GOWORK=off CGO_ENABLED=0 go build -o /tmp/validate-sector-alignment .
+
+      - name: Validate and export thresholds
+        id: thresholds
+        run: |
+          C="${COVERAGE_THRESHOLD_INPUT:-0.25}"
+          A="${ACCURACY_THRESHOLD_INPUT:-0.25}"
+          for value in "$C" "$A"; do
+            if ! printf '%s' "$value" | grep -Eq '^0(\.[0-9]+)?$|^1(\.0+)?$'; then
+              echo "Invalid threshold: $value (must be 0.0 - 1.0)" >&2
+              exit 1
+            fi
+          done
+          echo "coverage=$C" >> "$GITHUB_OUTPUT"
+          echo "accuracy=$A" >> "$GITHUB_OUTPUT"
+
+      - name: Validate and export since window
+        id: since
+        run: |
+          S="${SINCE_INPUT:-24h}"
+          if ! printf '%s' "$S" | grep -Eq '^([0-9]+(ns|us|ms|s|m|h))+$|^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$'; then
+            echo "Invalid since value: $S (must be a Go duration like 24h or RFC3339 timestamp)" >&2
+            exit 1
+          fi
+          echo "value=$S" >> "$GITHUB_OUTPUT"
+
+      - name: Configure SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Add server to known hosts
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || '22' }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keyscan -H -p "${DEPLOY_SSH_PORT}" "${DEPLOY_HOST}" >> ~/.ssh/known_hosts 2>/dev/null
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Run validator against production ES
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || '22' }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          COVERAGE_THRESHOLD: ${{ steps.thresholds.outputs.coverage }}
+          ACCURACY_THRESHOLD: ${{ steps.thresholds.outputs.accuracy }}
+          SINCE: ${{ steps.since.outputs.value }}
+        run: |
+          ssh -p "${DEPLOY_SSH_PORT}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            'mkdir -p /tmp/validate-sector-alignment-data'
+
+          scp -P "${DEPLOY_SSH_PORT}" /tmp/validate-sector-alignment \
+            "${DEPLOY_USER}@${DEPLOY_HOST}:/tmp/validate-sector-alignment"
+          scp -P "${DEPLOY_SSH_PORT}" source-manager/data/icp-segments.yml \
+            "${DEPLOY_USER}@${DEPLOY_HOST}:/tmp/validate-sector-alignment-data/icp-segments.yml"
+          scp -P "${DEPLOY_SSH_PORT}" classifier/testdata/icp_labels.yml \
+            "${DEPLOY_USER}@${DEPLOY_HOST}:/tmp/validate-sector-alignment-data/icp_labels.yml"
+
+          set +e
+          OUTPUT=$(ssh -p "${DEPLOY_SSH_PORT}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "docker run --rm --network=north-cloud_north-cloud-network \
+              -v /tmp/validate-sector-alignment:/validator:ro \
+              -v /tmp/validate-sector-alignment-data:/data:ro \
+              alpine:3 /validator \
+                -es http://elasticsearch:9200 \
+                -coverage-threshold ${COVERAGE_THRESHOLD} \
+                -accuracy-threshold ${ACCURACY_THRESHOLD} \
+                -since ${SINCE} \
+                -seed /data/icp-segments.yml \
+                -labels /data/icp_labels.yml" 2>&1)
+          STATUS=$?
+          set -e
+
+          echo "$OUTPUT"
+          {
+            echo "## Sector alignment validation"
+            echo ""
+            echo "Window: \`${SINCE}\`"
+            echo "Coverage threshold: \`${COVERAGE_THRESHOLD}\`"
+            echo "Accuracy threshold: \`${ACCURACY_THRESHOLD}\`"
+            echo ""
+            echo '```json'
+            echo "$OUTPUT"
+            echo '```'
+            echo ""
+            if [ "$STATUS" -eq 0 ]; then
+              echo "**PASS** - coverage and held-out accuracy met thresholds."
+            else
+              echo "**FAIL** - see #669. For private_sector_smb, distinguish zero production coverage from held-out classifier accuracy regression."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          ssh -p "${DEPLOY_SSH_PORT}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            'rm -f /tmp/validate-sector-alignment && rm -rf /tmp/validate-sector-alignment-data'
+
+          exit $STATUS

--- a/source-manager/internal/icpstore/store_test.go
+++ b/source-manager/internal/icpstore/store_test.go
@@ -1,4 +1,4 @@
-package icpstore
+package icpstore_test
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	infralogger "github.com/jonesrussell/north-cloud/infrastructure/logger"
+	"github.com/jonesrussell/north-cloud/source-manager/internal/icpstore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +16,7 @@ func TestStoreReloadsSeedWithoutRestart(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "icp-segments.yml")
 	require.NoError(t, os.WriteFile(path, []byte(testSeedYAML("2026-04-26")), 0o600))
 
-	store, err := New(path, 25*time.Millisecond, infralogger.NewNop())
+	store, err := icpstore.New(path, 25*time.Millisecond, infralogger.NewNop())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tools/validate-sector-alignment/go.mod
+++ b/tools/validate-sector-alignment/go.mod
@@ -1,0 +1,12 @@
+module github.com/jonesrussell/north-cloud/tools/validate-sector-alignment
+
+go 1.26.2
+
+require (
+	github.com/jonesrussell/north-cloud/infrastructure v0.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require github.com/stretchr/testify v1.11.1 // indirect
+
+replace github.com/jonesrussell/north-cloud/infrastructure => ../../infrastructure

--- a/tools/validate-sector-alignment/go.sum
+++ b/tools/validate-sector-alignment/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/validate-sector-alignment/main.go
+++ b/tools/validate-sector-alignment/main.go
@@ -1,0 +1,416 @@
+// Command validate-sector-alignment measures classifier sector_alignment health.
+//
+// It emits one structured JSON report with two gates:
+//   - coverage: fraction of recently classified docs with non-empty icp.segments[]
+//   - accuracy: per-segment precision/recall/F1 against classifier/testdata/icp_labels.yml
+//
+// Exit codes:
+//   - 0: both gates pass
+//   - 1: a gate fails, input is invalid, or Elasticsearch is unavailable
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jonesrussell/north-cloud/infrastructure/icp"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultAccuracyThreshold  = 0.25
+	defaultCoverageThreshold  = 0.25
+	defaultESURL              = "http://localhost:9200"
+	defaultHTTPTimeoutSeconds = 15
+	defaultSince              = "24h"
+	indexPattern              = "*_classified_content"
+	rangeField                = "crawled_at"
+)
+
+var requiredSegments = []string{
+	"indigenous_channel",
+	"northern_ontario_industry",
+	"private_sector_smb",
+}
+
+type labelsFile struct {
+	SegmentSchemaVersion int      `yaml:"segment_schema_version"`
+	Segments             []string `yaml:"segments"`
+	Labels               []label  `yaml:"labels"`
+}
+
+type label struct {
+	DocID    string            `yaml:"doc_id"`
+	Title    string            `yaml:"title"`
+	Excerpt  string            `yaml:"excerpt"`
+	Segments map[string]string `yaml:"segments"`
+}
+
+type countResponse struct {
+	Count int64 `json:"count"`
+}
+
+type report struct {
+	GeneratedAt string         `json:"generated_at"`
+	Pass        bool           `json:"pass"`
+	Coverage    coverageReport `json:"coverage"`
+	Accuracy    accuracyReport `json:"accuracy"`
+	Notes       []string       `json:"notes,omitempty"`
+}
+
+type coverageReport struct {
+	IndexPattern      string           `json:"index_pattern"`
+	Since             string           `json:"since"`
+	Threshold         float64          `json:"threshold"`
+	TotalDocs         int64            `json:"total_docs"`
+	DocsWithSegments  int64            `json:"docs_with_segments"`
+	PopulatedRate     float64          `json:"populated_rate"`
+	SegmentHitCounts  map[string]int64 `json:"segment_hit_counts"`
+	SMBSignalObserved bool             `json:"smb_signal_observed"`
+	Pass              bool             `json:"pass"`
+}
+
+type accuracyReport struct {
+	SeedModelVersion string                    `json:"seed_model_version"`
+	LabelsPath       string                    `json:"labels_path"`
+	Threshold        float64                   `json:"threshold"`
+	Segments         map[string]segmentMetrics `json:"segments"`
+	Pass             bool                      `json:"pass"`
+}
+
+type segmentMetrics struct {
+	TruePositive   int64   `json:"true_positive"`
+	FalsePositive  int64   `json:"false_positive"`
+	FalseNegative  int64   `json:"false_negative"`
+	TrueNegative   int64   `json:"true_negative"`
+	IgnoredPartial int64   `json:"ignored_partial"`
+	Precision      float64 `json:"precision"`
+	Recall         float64 `json:"recall"`
+	F1             float64 `json:"f1"`
+	Pass           bool    `json:"pass"`
+}
+
+func main() {
+	esDefault := defaultESURL
+	if v := os.Getenv("ELASTICSEARCH_URL"); v != "" { //nolint:forbidigo // standalone CLI reads one env var directly
+		esDefault = v
+	}
+	esURL := flag.String("es", esDefault, "Elasticsearch base URL")
+	sinceRaw := flag.String("since", defaultSince, "Only count documents with crawled_at >= this RFC3339 timestamp or duration")
+	coverageThreshold := flag.Float64("coverage-threshold", defaultCoverageThreshold, "Minimum sector_alignment coverage rate")
+	accuracyThreshold := flag.Float64("accuracy-threshold", defaultAccuracyThreshold, "Minimum per-segment held-out F1")
+	seedPath := flag.String("seed", "source-manager/data/icp-segments.yml", "Path to ICP seed YAML")
+	labelsPath := flag.String("labels", "classifier/testdata/icp_labels.yml", "Path to ICP labels YAML")
+	flag.Parse()
+
+	if err := validateThreshold(*coverageThreshold); err != nil {
+		fail("invalid -coverage-threshold: %v", err)
+	}
+	if err := validateThreshold(*accuracyThreshold); err != nil {
+		fail("invalid -accuracy-threshold: %v", err)
+	}
+
+	since, err := parseSince(*sinceRaw, time.Now)
+	if err != nil {
+		fail("invalid -since: %v", err)
+	}
+
+	seed, err := icp.LoadSeed(*seedPath)
+	if err != nil {
+		fail("seed validation failed: %v", err)
+	}
+	labels, err := loadLabels(*labelsPath)
+	if err != nil {
+		fail("labels validation failed: %v", err)
+	}
+
+	ctx := context.Background()
+	client := &http.Client{Timeout: defaultHTTPTimeoutSeconds * time.Second}
+	coverage, err := measureCoverage(ctx, client, strings.TrimRight(*esURL, "/"), since, *coverageThreshold)
+	if err != nil {
+		fail("coverage validation failed: %v", err)
+	}
+	accuracy := measureAccuracy(seed, labels, *labelsPath, *accuracyThreshold)
+
+	out := report{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Coverage:    coverage,
+		Accuracy:    accuracy,
+		Pass:        coverage.Pass && accuracy.Pass,
+	}
+	if !coverage.SMBSignalObserved {
+		out.Notes = append(out.Notes,
+			"private_sector_smb had zero production segment hits in this window; treat that as corpus/ingestion coverage risk before reading it as classifier accuracy regression")
+	}
+
+	encoded, marshalErr := json.MarshalIndent(out, "", "  ")
+	if marshalErr != nil {
+		fail("marshal report: %v", marshalErr)
+	}
+	fmt.Println(string(encoded))
+	if !out.Pass {
+		os.Exit(1)
+	}
+}
+
+func parseSince(raw string, now func() time.Time) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return parsed.Format(time.RFC3339Nano), nil
+	}
+	duration, err := time.ParseDuration(raw)
+	if err != nil {
+		return "", fmt.Errorf("expected RFC3339 timestamp or duration: %w", err)
+	}
+	if duration <= 0 {
+		return "", errors.New("duration must be positive")
+	}
+	return now().UTC().Add(-duration).Format(time.RFC3339Nano), nil
+}
+
+func validateThreshold(value float64) error {
+	if value < 0 || value > 1 {
+		return errors.New("must be between 0.0 and 1.0")
+	}
+	return nil
+}
+
+func loadLabels(path string) ([]label, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var file labelsFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	if file.SegmentSchemaVersion != 1 {
+		return nil, fmt.Errorf("segment_schema_version must be 1, got %d", file.SegmentSchemaVersion)
+	}
+	for _, segment := range requiredSegments {
+		if !slices.Contains(file.Segments, segment) {
+			return nil, fmt.Errorf("missing labels segment %q", segment)
+		}
+	}
+	if len(file.Labels) == 0 {
+		return nil, errors.New("labels must contain at least one item")
+	}
+	for i, item := range file.Labels {
+		if strings.TrimSpace(item.DocID) == "" || strings.TrimSpace(item.Title) == "" || strings.TrimSpace(item.Excerpt) == "" {
+			return nil, fmt.Errorf("labels[%d] doc_id, title, and excerpt are required", i)
+		}
+		for _, segment := range requiredSegments {
+			value, ok := item.Segments[segment]
+			if !ok {
+				return nil, fmt.Errorf("labels[%d].segments missing %q", i, segment)
+			}
+			if !slices.Contains([]string{"strong", "partial", "none"}, value) {
+				return nil, fmt.Errorf("labels[%d].segments.%s is invalid", i, segment)
+			}
+		}
+	}
+	return file.Labels, nil
+}
+
+func measureCoverage(ctx context.Context, client *http.Client, esURL, since string, threshold float64) (coverageReport, error) {
+	total, err := count(ctx, client, esURL, indexPattern, coverageTotalQuery(since))
+	if err != nil {
+		return coverageReport{}, fmt.Errorf("total docs: %w", err)
+	}
+	withSegments, err := count(ctx, client, esURL, indexPattern, coverageAnySegmentQuery(since))
+	if err != nil {
+		return coverageReport{}, fmt.Errorf("docs with ICP segments: %w", err)
+	}
+	segmentHits := make(map[string]int64, len(requiredSegments))
+	for _, segment := range requiredSegments {
+		hits, hitErr := count(ctx, client, esURL, indexPattern, coverageSegmentQuery(segment, since))
+		if hitErr != nil {
+			return coverageReport{}, fmt.Errorf("segment %s hits: %w", segment, hitErr)
+		}
+		segmentHits[segment] = hits
+	}
+	populatedRate := rate(withSegments, total)
+	return coverageReport{
+		IndexPattern:      indexPattern,
+		Since:             since,
+		Threshold:         threshold,
+		TotalDocs:         total,
+		DocsWithSegments:  withSegments,
+		PopulatedRate:     populatedRate,
+		SegmentHitCounts:  segmentHits,
+		SMBSignalObserved: segmentHits["private_sector_smb"] > 0,
+		Pass:              total > 0 && populatedRate >= threshold,
+	}, nil
+}
+
+func coverageTotalQuery(since string) map[string]any {
+	return map[string]any{"query": map[string]any{"bool": map[string]any{"filter": rangeFilters(since)}}}
+}
+
+func coverageAnySegmentQuery(since string) map[string]any {
+	filters := rangeFilters(since)
+	filters = append(filters, map[string]any{
+		"nested": map[string]any{
+			"path":  "icp.segments",
+			"query": map[string]any{"exists": map[string]any{"field": "icp.segments.segment"}},
+		},
+	})
+	return map[string]any{"query": map[string]any{"bool": map[string]any{"filter": filters}}}
+}
+
+func coverageSegmentQuery(segment, since string) map[string]any {
+	filters := rangeFilters(since)
+	filters = append(filters, map[string]any{
+		"nested": map[string]any{
+			"path": "icp.segments",
+			"query": map[string]any{
+				"term": map[string]any{"icp.segments.segment": segment},
+			},
+		},
+	})
+	return map[string]any{"query": map[string]any{"bool": map[string]any{"filter": filters}}}
+}
+
+func rangeFilters(since string) []map[string]any {
+	if since == "" {
+		return []map[string]any{}
+	}
+	return []map[string]any{{
+		"range": map[string]any{
+			rangeField: map[string]any{"gte": since},
+		},
+	}}
+}
+
+func count(ctx context.Context, client *http.Client, esURL, index string, body map[string]any) (int64, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return 0, fmt.Errorf("marshal body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, esURL+"/"+index+"/_count", bytes.NewReader(buf))
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return 0, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed countResponse
+	if unmarshalErr := json.Unmarshal(respBody, &parsed); unmarshalErr != nil {
+		return 0, fmt.Errorf("decode response: %w", unmarshalErr)
+	}
+	return parsed.Count, nil
+}
+
+func measureAccuracy(seed *icp.Seed, labels []label, labelsPath string, threshold float64) accuracyReport {
+	metrics := make(map[string]segmentMetrics, len(requiredSegments))
+	for _, segment := range requiredSegments {
+		metrics[segment] = segmentMetrics{}
+	}
+	for _, item := range labels {
+		predicted := predictedSegments(seed, item)
+		for _, segment := range requiredSegments {
+			m := metrics[segment]
+			switch item.Segments[segment] {
+			case "partial":
+				m.IgnoredPartial++
+			case "strong":
+				if predicted[segment] {
+					m.TruePositive++
+				} else {
+					m.FalseNegative++
+				}
+			case "none":
+				if predicted[segment] {
+					m.FalsePositive++
+				} else {
+					m.TrueNegative++
+				}
+			}
+			metrics[segment] = m
+		}
+	}
+
+	pass := true
+	for _, segment := range requiredSegments {
+		m := metrics[segment]
+		m.Precision = rate(m.TruePositive, m.TruePositive+m.FalsePositive)
+		m.Recall = rate(m.TruePositive, m.TruePositive+m.FalseNegative)
+		m.F1 = f1(m.Precision, m.Recall)
+		if m.TruePositive+m.FalseNegative == 0 {
+			m.Pass = m.FalsePositive == 0
+		} else {
+			m.Pass = m.F1 >= threshold
+		}
+		if !m.Pass {
+			pass = false
+		}
+		metrics[segment] = m
+	}
+
+	return accuracyReport{
+		SeedModelVersion: icp.ModelVersionV1,
+		LabelsPath:       labelsPath,
+		Threshold:        threshold,
+		Segments:         metrics,
+		Pass:             pass,
+	}
+}
+
+func predictedSegments(seed *icp.Seed, item label) map[string]bool {
+	predicted := make(map[string]bool, len(requiredSegments))
+	result := icp.Match(seed, icp.Document{
+		Title: item.Title,
+		Body:  item.Excerpt,
+	})
+	if result == nil {
+		return predicted
+	}
+	for _, segment := range result.Segments {
+		predicted[segment.Segment] = true
+	}
+	return predicted
+}
+
+func rate(num, denom int64) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return float64(num) / float64(denom)
+}
+
+func f1(precision, recall float64) float64 {
+	if precision+recall == 0 {
+		return 0
+	}
+	return 2 * precision * recall / (precision + recall)
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/tools/validate-sector-alignment/main_test.go
+++ b/tools/validate-sector-alignment/main_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jonesrussell/north-cloud/infrastructure/icp"
+)
+
+func TestParseSinceDuration(t *testing.T) {
+	t.Parallel()
+
+	now := func() time.Time {
+		return time.Date(2026, 4, 26, 20, 0, 0, 0, time.UTC)
+	}
+	got, err := parseSince("24h", now)
+	if err != nil {
+		t.Fatalf("parseSince returned error: %v", err)
+	}
+	if got != "2026-04-25T20:00:00Z" {
+		t.Fatalf("parseSince() = %q", got)
+	}
+}
+
+func TestParseSinceRejectsNegativeDuration(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseSince("-1h", time.Now); err == nil {
+		t.Fatal("parseSince accepted negative duration")
+	}
+}
+
+func TestCoverageSegmentQueryUsesNestedSegmentFilter(t *testing.T) {
+	t.Parallel()
+
+	body := coverageSegmentQuery("private_sector_smb", "2026-04-25T20:00:00Z")
+	mustJSON(t, body)
+
+	filters := queryFilters(t, body)
+	if len(filters) != 2 {
+		t.Fatalf("len(filters) = %d", len(filters))
+	}
+	nested, ok := filters[1]["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested filter missing: %#v", filters[1])
+	}
+	if got := nested["path"]; got != "icp.segments" {
+		t.Fatalf("nested path = %v", got)
+	}
+	query := nested["query"].(map[string]any)
+	term := query["term"].(map[string]any)
+	if got := term["icp.segments.segment"]; got != "private_sector_smb" {
+		t.Fatalf("segment term = %v", got)
+	}
+}
+
+func TestMeasureAccuracyIgnoresPartialLabels(t *testing.T) {
+	t.Parallel()
+
+	seed := &icp.Seed{
+		SegmentSchemaVersion: 1,
+		SeedUpdatedAt:        "2026-04-26",
+		Segments: []icp.Segment{
+			{Name: "indigenous_channel", Description: "Indigenous", Keywords: []string{"First Nation"}, MinScore: 0.30},
+			{Name: "northern_ontario_industry", Description: "NOI", Keywords: []string{"Sudbury"}, MinScore: 0.30},
+			{Name: "private_sector_smb", Description: "SMB", Keywords: []string{"privately held"}, MinScore: 0.30},
+		},
+	}
+	labels := []label{
+		{
+			DocID:   "strong_hit",
+			Title:   "First Nation broadband authority",
+			Excerpt: "A First Nation project in Canada",
+			Segments: map[string]string{
+				"indigenous_channel":        "strong",
+				"northern_ontario_industry": "none",
+				"private_sector_smb":        "none",
+			},
+		},
+		{
+			DocID:   "partial_ignored",
+			Title:   "Sudbury consultancy",
+			Excerpt: "A privately held firm",
+			Segments: map[string]string{
+				"indigenous_channel":        "none",
+				"northern_ontario_industry": "partial",
+				"private_sector_smb":        "strong",
+			},
+		},
+	}
+
+	report := measureAccuracy(seed, labels, "labels.yml", 0.01)
+	if !report.Pass {
+		t.Fatal("measureAccuracy() did not pass")
+	}
+	if got := report.Segments["northern_ontario_industry"].IgnoredPartial; got != 1 {
+		t.Fatalf("IgnoredPartial = %d", got)
+	}
+	if got := report.Segments["private_sector_smb"].TruePositive; got != 1 {
+		t.Fatalf("private_sector_smb TP = %d", got)
+	}
+}
+
+func queryFilters(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	query, ok := body["query"].(map[string]any)
+	if !ok {
+		t.Fatalf("query missing: %#v", body)
+	}
+	boolQuery, ok := query["bool"].(map[string]any)
+	if !ok {
+		t.Fatalf("bool query missing: %#v", query)
+	}
+	filters, ok := boolQuery["filter"].([]map[string]any)
+	if !ok {
+		t.Fatalf("filter missing: %#v", boolQuery)
+	}
+	return filters
+}
+
+func mustJSON(t *testing.T, value any) {
+	t.Helper()
+
+	if _, err := json.Marshal(value); err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the #669 sector_alignment validator path:

- adds `tools/validate-sector-alignment`, a standalone Go validator that emits structured JSON
- measures production coverage as the rate of recent `*_classified_content` docs with non-empty `icp.segments[]`
- scores held-out accuracy against `classifier/testdata/icp_labels.yml` using the v1 ICP seed and matcher
- emits precision / recall / F1 per segment, ignoring `partial` labels for binary accuracy scoring
- adds a nightly and manually dispatchable GitHub Actions workflow mirroring the org-attribution validator deployment shape

## Initial Thresholds / Promotion

Initial gates are intentionally permissive while the validator earns trust on live data:

- coverage threshold: `0.25`
- per-segment held-out F1 threshold: `0.25`
- promotion target noted in workflow comments: raise coverage to `0.80+` and accuracy to `0.70+` after 14 consecutive clean `--since 24h` production runs

The dry-run held-out corpus score currently shows perfect precision but low recall on v1 seed matching, especially `private_sector_smb`, which is why the earned-promotion floor starts low.

The validator also emits an SMB-specific note when production `private_sector_smb` segment hits are zero, so an ingestion/corpus coverage problem is not misread as a classifier accuracy regression.

## Validation

- [x] `GOWORK=off go test ./...` from `tools/validate-sector-alignment`
- [x] mock-ES dry run with real `source-manager/data/icp-segments.yml` and `classifier/testdata/icp_labels.yml`
- [x] `git diff --check HEAD~1 HEAD`

Refs #669