### PR TITLE
fix(icp): tune seed for live coverage

### DIFF
--- a/docs/specs/source-manager.md
+++ b/docs/specs/source-manager.md
@@ -1,6 +1,6 @@
 # Source Manager Specification
 
-> Last verified: 2026-04-26 (ICP segment seed file, schema, hot-reload store, and public seed endpoint added)
+> Last verified: 2026-04-26 (ICP segment seed file, schema, hot-reload store, public seed endpoint, and live-coverage seed tuning verified)
 
 ## Purpose
 
@@ -139,6 +139,8 @@ Supporting tables for office contacts and leadership audit trail.
 ## ICP Segment Seed
 
 `source-manager/data/icp-segments.yml` is the source of truth for the initial sector-alignment seed. The file is validated by `source-manager/data/icp-segments.schema.json`, `infrastructure/icp.ValidateSeed`, and the `tools/validate-icp-data` CI job. The seed currently carries three canonical segments: `indigenous_channel`, `northern_ontario_industry`, and `private_sector_smb`.
+
+The seed is tuned against both the held-out label corpus and live validator coverage. Plain `Indigenous` is an allowed `indigenous_channel` keyword/required signal so live Indigenous-topic content does not require a more specific Nation/community term before it can align. `private_sector_smb` uses a 0.30 minimum score to allow sparse but explicit SMB signals while still relying on the validator label corpus to catch false positives.
 
 At startup, source-manager loads the seed through `internal/icpstore.Store`. The store keeps the current seed in an atomic pointer, watches the seed directory with `fsnotify`, and also runs a periodic reload every `ICP_RELOAD_INTERVAL`. If file watching is unavailable, it falls back to periodic reload only. Reload errors are logged and the last good seed remains active.
 

--- a/source-manager/data/icp-segments.yml
+++ b/source-manager/data/icp-segments.yml
@@ -8,6 +8,7 @@ segments:
     keywords:
       - "First Nation"
       - "First Nations"
+      - "Indigenous"
       - "Indigenous-owned"
       - "Indigenous business"
       - "Indigenous procurement"
@@ -29,6 +30,7 @@ segments:
     required_any:
       - "First Nation"
       - "First Nations"
+      - "Indigenous"
       - "Metis"
       - "Inuit"
       - "treaty"
@@ -100,4 +102,4 @@ segments:
     topics:
       - "business"
       - "technology"
-    min_score: 0.35
+    min_score: 0.30


### PR DESCRIPTION
## Summary
- include plain Indigenous as an indigenous_channel keyword and required_any signal so live Indigenous-topic content can earn ICP alignment
- lower private_sector_smb min_score from 0.35 to 0.30 for sparse live SMB signals

## Validation
- GOWORK=off go run . -seed ../../source-manager/data/icp-segments.yml -labels ../../classifier/testdata/icp_labels.yml
- GOWORK=off go test ./internal/icpstore

## Notes
- This follows the live/dev validator dry run where classifier seed fetch worked, but live examples with obvious Indigenous signals returned icp=null due seed strictness.