### PR TITLE
docs(mission-A WP02): document ml-modules and ml-framework architecture

### DIFF
--- a/kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP02-ml-modules-framework-triage.md
+++ b/kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP02-ml-modules-framework-triage.md
@@ -1,0 +1,81 @@
+# WP02 — `ml-modules/` and `ml-framework/` triage
+
+**Mission**: `audit-dead-code-removal-01KQG57Z`
+**Issue**: #698
+**Spec refs**: FR-003, FR-005, FR-007
+**Dependencies**: WP01
+
+## Outcome: documented, not deleted
+
+The 2026-04-30 audit's "no consumers" hypothesis for `ml-modules/` and `ml-framework/` was **incorrect**. Both directories are live, production code. WP02 instead takes the spec FR-003 conditional path: *"If populated with intent, document and either fold into ml-sidecars/ or open a follow-up mission."* This WP adds two READMEs documenting the architecture and closes #698 as "audit was wrong; keep with docs". No directory is deleted.
+
+## Evidence the audit was wrong
+
+| Claim in audit | Reality |
+|---|---|
+| "Sibling directories to the active `ml-sidecars/`" | True, but they are **collaborators**, not duplicates. Three-tier architecture: framework + modules + sidecars. |
+| "No README, no documented purpose" | True — addressed by this WP. |
+| "Not referenced in classifier client code" | Technically true (classifier reaches sidecars via HTTP), but irrelevant — `ml-sidecars/` itself **imports `nc_ml` from `ml-framework/`** in every sidecar's `module.py`. |
+
+Verifying greps performed in this WP's worktree (origin/main HEAD `091fe4d9`):
+
+```bash
+grep -rln 'from nc_ml' ml-sidecars/
+# → ml-sidecars/{coforge,crime,entertainment,indigenous,mining}-ml/module.py
+
+grep -lE 'ml-modules|ml-framework' docker-compose*.yml
+# → docker-compose.dev.yml
+
+grep -B1 -A3 'ml-modules\|ml-framework' docker-compose.dev.yml
+# → 5 ml-* sidecar services each mount:
+#     - ./ml-modules/<topic>:/opt/module
+#     - ./ml-framework:/opt/ml-framework
+```
+
+`ml-framework/pyproject.toml` declares the package as `nc-ml v1.0.0 — North Cloud ML Sidecar Framework`. The `nc_ml.main` entry point dynamically imports the topic module from `/opt/module` at sidecar startup. Each `ml-modules/{topic}/module.py` subclasses `nc_ml.module.ClassifierModule`. Each `ml-sidecars/{topic}-ml/module.py` is a near-identical copy (production build artifact).
+
+## Architecture (now documented in the new READMEs)
+
+```
+ml-framework/        → shared FastAPI framework + module protocol (nc_ml package)
+ml-modules/{topic}/  → per-topic source-of-truth ClassifierModule implementations
+ml-sidecars/{topic}-ml/ → production Docker build contexts (embed module code)
+```
+
+In dev: `docker-compose.dev.yml` mounts `ml-modules/{topic}` and `ml-framework` as volumes; live edit, no rebuild.
+In prod: `ml-sidecars/{topic}-ml/Dockerfile` copies module code into image; `nc_ml` installed as a dependency.
+
+5 active topics (1:1 mapping): `coforge`, `crime`, `entertainment`, `indigenous`, `mining` — matching publisher routing layers L8/L3/L6/L7/L5 respectively.
+
+## Changes in this WP
+
+| File | Action |
+|---|---|
+| `ml-framework/README.md` | **New** — documents the `nc_ml` framework, the module protocol, and the dev-vs-prod loading mechanism. |
+| `ml-modules/README.md` | **New** — documents the per-topic source-of-truth pattern, subdirectory layout, the dev mount pattern, and a drift note about `ml-sidecars/{topic}-ml/module.py` mirroring. |
+
+No code changed. No directories deleted. No compose files edited.
+
+## Out of scope (possible follow-ups)
+
+- **Drift between `ml-modules/{topic}/module.py` and `ml-sidecars/{topic}-ml/module.py`** — these should mirror, but no automation enforces it. A follow-up could either auto-sync them at build time or pick one as the canonical source.
+- **Folding `ml-modules/` and `ml-framework/` into `ml-sidecars/`** — explicitly evaluated and rejected: would lose the dev live-edit ergonomics and require Dockerfile changes per sidecar. The 3-tier architecture is intentional.
+- **Updating Mission A's `spec.md`/`research.md`** to retract the audit's claim — left as historical record of what the audit said. This WP02 doc is the corrected record.
+- **Updating root `ARCHITECTURE.md`** to reference the new READMEs — out of scope per DIR-004 (no while-I'm-here).
+
+## Verification
+
+- `task drift:check` — green (no spec touched)
+- `task layers:check` — green (no Go imports changed)
+- `task ports:check` — green (no compose changed)
+- No Go code touched → no `task lint` / `task test` deltas
+
+## Acceptance
+
+- Both new READMEs land on `main`.
+- `ml-modules/` and `ml-framework/` remain unchanged in code.
+- Issue #698 closed via `Closes #698`, with body explaining the audit revision.
+
+## Conclusion
+
+Spec FR-003's "document the keepers" path is the right call. `ml-modules/` and `ml-framework/` are an active 3-tier ML architecture; the audit just hadn't seen the dev compose mounts or the `nc_ml` framework's role. Adding the two READMEs prevents the next code-smell pass from making the same mistake.

--- a/ml-framework/README.md
+++ b/ml-framework/README.md
@@ -1,0 +1,64 @@
+# ml-framework — `nc_ml`
+
+Shared Python framework powering every ML sidecar in `ml-sidecars/`.
+
+## What it is
+
+A small FastAPI-based framework that handles the cross-cutting concerns every classification sidecar needs: app construction, model loading, request schemas, health checks, structured logging, Prometheus metrics, and a dynamic module-loader entry point. Each sidecar implements the `ClassifierModule` protocol from `nc_ml.module` and the framework wraps it into a uvicorn-served `POST /classify` + `GET /health` HTTP API.
+
+Distributed as a local Python package (`pyproject.toml`, `name = "nc-ml"`, `version = "1.0.0"`).
+
+## Architecture
+
+This directory is the framework half of a 3-tier ML pipeline:
+
+```
+ml-framework/        → shared FastAPI framework + module protocol (this dir)
+ml-modules/{topic}/  → per-topic source-of-truth ClassifierModule implementations
+ml-sidecars/{topic}-ml/ → production Docker build contexts (embed the module code)
+```
+
+In **dev** (`docker-compose.dev.yml` `ml` profile), each sidecar container mounts both `./ml-modules/{topic}:/opt/module` and `./ml-framework:/opt/ml-framework`, then the framework's `nc_ml.main` entry point reads `MODULE_NAME=<topic>` from env and dynamically imports the module from `/opt/module`. This gives live-edit ergonomics for sidecar development without rebuilding images.
+
+In **production**, sidecar images are built from `ml-sidecars/{topic}-ml/Dockerfile` with the topic module's code copied in directly — `nc_ml` is installed as a regular dependency.
+
+## Layout
+
+```
+ml-framework/
+├── pyproject.toml          # name = "nc-ml", version = "1.0.0"
+└── nc_ml/
+    ├── app.py              # FastAPI app factory
+    ├── main.py             # Entry point: imports module by MODULE_NAME env, creates app
+    ├── module.py           # Abstract base classes: BaseModule, ClassifierModule, ExtractorModule
+    ├── schemas.py          # Pydantic request/response schemas (ClassifyRequest, ClassifierResult)
+    ├── model_loader.py     # joblib model loading utilities
+    ├── health.py           # Health-check aggregator
+    ├── logging.py          # structlog setup
+    ├── metrics.py          # prometheus-client integration
+    └── middleware.py       # FastAPI middleware (request logging, error handling)
+```
+
+## Module protocol
+
+Every sidecar's topic module subclasses `ClassifierModule` from `nc_ml.module`:
+
+```python
+from nc_ml.module import ClassifierModule
+from nc_ml.schemas import ClassifyRequest, ClassifierResult
+
+class MyTopicModule(ClassifierModule):
+    def name(self) -> str: ...
+    def version(self) -> str: ...
+    def schema_version(self) -> str: ...
+    async def initialize(self) -> None: ...      # load models
+    async def shutdown(self) -> None: ...        # release resources
+    async def health_checks(self) -> dict[str, bool]: ...
+    async def classify(self, request: ClassifyRequest) -> ClassifierResult: ...
+```
+
+## Orchestration
+
+For the consumer-facing API surface (`POST /classify` request schema, sidecar registration in the Classifier service, dev profiles in compose), see `ml-sidecars/README.md`.
+
+For project-wide architecture context (charter, content pipeline layers, publisher routing), see the root `CLAUDE.md` and `docs/specs/classification.md`.

--- a/ml-modules/README.md
+++ b/ml-modules/README.md
@@ -1,0 +1,63 @@
+# ml-modules — per-topic classifier modules
+
+Source-of-truth implementations of the `ClassifierModule` protocol from `ml-framework/nc_ml`. Each subdirectory is one ML domain (mining, crime, indigenous, entertainment, coforge) and is **mounted into the corresponding ML sidecar container at `/opt/module`** in dev.
+
+## What it is
+
+Five topic-specific Python packages, each exposing a `ClassifierModule` subclass that the `nc_ml` framework loads dynamically at sidecar startup. Each module owns its own:
+
+- ML model artifacts (joblib files under `models/`)
+- Per-classifier code (e.g., `classifier/relevance.py`, `classifier/commodity.py`)
+- Pydantic result schemas extending `ClassifierResult`
+- `requirements.txt` or `pyproject.toml` for module-specific deps (typically `scikit-learn`, `joblib`)
+
+## Architecture
+
+This directory is the topic-modules half of a 3-tier ML pipeline:
+
+```
+ml-framework/        → shared FastAPI framework + module protocol
+ml-modules/{topic}/  → per-topic source-of-truth ClassifierModule implementations (this dir)
+ml-sidecars/{topic}-ml/ → production Docker build contexts (embed the module code at build time)
+```
+
+In **dev** (`docker-compose.dev.yml` `ml` profile), each sidecar mounts both `./ml-modules/{topic}:/opt/module` and `./ml-framework:/opt/ml-framework`, then `nc_ml.main` reads `MODULE_NAME=<topic>` and dynamically imports the module from `/opt/module`. Edits here take effect on container restart, no image rebuild.
+
+In **production**, the corresponding `ml-sidecars/{topic}-ml/Dockerfile` copies the module's code into the image and installs `nc_ml` as a regular dependency. The `ml-sidecars/{topic}-ml/module.py` files are build artifacts that mirror `ml-modules/{topic}/module.py`.
+
+## Subdirectories
+
+| Topic | Purpose | Sidecar pair |
+|---|---|---|
+| `coforge/` | CoForge classification (publisher routing layer L8) | `ml-sidecars/coforge-ml` |
+| `crime/` | Street-crime classification (publisher routing layer L3) | `ml-sidecars/crime-ml` |
+| `entertainment/` | Entertainment classification (publisher routing layer L6) | `ml-sidecars/entertainment-ml` |
+| `indigenous/` | Indigenous classification (publisher routing layer L7) | `ml-sidecars/indigenous-ml` |
+| `mining/` | Mining classification (publisher routing layer L5) | `ml-sidecars/mining-ml` |
+
+Each subdirectory typically contains:
+
+```
+ml-modules/{topic}/
+├── __init__.py
+├── module.py              # ClassifierModule subclass; framework entry point
+├── classifier/            # per-classifier algorithms (one .py per classifier)
+├── models/                # joblib model artifacts
+└── requirements.txt OR pyproject.toml
+```
+
+## Adding a new topic module
+
+Per root `CLAUDE.md`:
+
+1. Create `ml-modules/<name>/` following the layout above
+2. Add `<NAME>_ENABLED` and `<NAME>_ML_SERVICE_URL` to `classifier/internal/config/`
+3. Add a routing layer in `publisher/`
+4. Add the dev sidecar service to `docker-compose.dev.yml` under the `ml` profile (mount both `./ml-modules/<name>` and `./ml-framework`)
+5. Create `ml-sidecars/<name>-ml/` build context with Dockerfile
+
+See `classifier/CLAUDE.md` and `ml-sidecars/README.md` for the API contract.
+
+## Drift note
+
+The `module.py` in `ml-modules/{topic}/` and `ml-sidecars/{topic}-ml/` are intended to mirror each other. If they drift, the sidecar's image rebuild will use the `ml-sidecars/` copy in production while dev runs from `ml-modules/`. Tracking this drift is out of scope for the current audit; consider a follow-up to auto-sync them or treat one as the canonical source.


### PR DESCRIPTION
## Summary

Mission A WP02 (issue #698) — **the audit was wrong**. \`ml-modules/\` and \`ml-framework/\` are not orphans; they are an active 3-tier ML architecture. Per spec FR-003's conditional ("if populated with intent, document and either fold or open follow-up"), this PR takes the **document-the-keepers** path. Adds two READMEs and the WP02 prompt file. **No code or compose changed. No directories deleted.**

## Architecture (now documented)

\`\`\`
ml-framework/        → shared FastAPI framework (nc_ml package, v1.0.0)
ml-modules/{topic}/  → per-topic source-of-truth ClassifierModule implementations
ml-sidecars/{topic}-ml/ → production Docker build contexts (embed module code)
\`\`\`

In **dev** (\`docker-compose.dev.yml\` \`ml\` profile), each sidecar mounts \`./ml-modules/{topic}:/opt/module\` + \`./ml-framework:/opt/ml-framework\` and \`nc_ml.main\` dynamically imports by \`MODULE_NAME\` env. Live edit, no rebuild.
In **prod**, \`ml-sidecars/{topic}-ml/Dockerfile\` copies module code into the image and installs \`nc_ml\` as a dep.

5 active topics with 1:1 sidecar mapping: \`coforge\`, \`crime\`, \`entertainment\`, \`indigenous\`, \`mining\` — matching publisher routing layers L8/L3/L6/L7/L5.

## Why the audit was wrong

| Audit claim | Reality |
|---|---|
| "Sibling directories to the active ml-sidecars/" | True, but **collaborators**, not duplicates |
| "No README, no documented purpose" | True — fixed by this PR |
| "Not referenced in classifier client code" | Technically true (classifier reaches sidecars via HTTP), but every \`ml-sidecars/{topic}-ml/module.py\` **imports from \`nc_ml\`** in \`ml-framework/\` |

Verifying greps (origin/main \`091fe4d9\`):
- \`grep -rln 'from nc_ml' ml-sidecars/\` → all 5 sidecars match
- \`grep -lE 'ml-modules|ml-framework' docker-compose*.yml\` → \`docker-compose.dev.yml\` (5 mount entries)
- \`ml-framework/pyproject.toml\` declares \`name = "nc-ml"\`, \`description = "North Cloud ML Sidecar Framework"\`

## Files added

| File | Purpose |
|---|---|
| \`ml-framework/README.md\` | Documents the \`nc_ml\` framework, the module protocol, dev/prod loading mechanism |
| \`ml-modules/README.md\` | Documents the per-topic source-of-truth pattern, layout, drift note vs \`ml-sidecars/\` |
| \`kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP02-ml-modules-framework-triage.md\` | WP02 prompt file with full evidence and rationale |

## Charter check

- **DIR-001** ✓ — ML pipeline is in scope; correcting audit error doesn't affect risk boundary
- **DIR-002** ✓ — adds documentation that was missing
- **DIR-003** ✓ — no Go code changed
- **DIR-004** ✓ — single PR for single WP, no abstractions added, didn't fold into ml-sidecars/ (out of scope, deferred to possible follow-up)

## Gates verified locally

- \`task drift:check\` GREEN
- \`task layers:check\` GREEN
- \`task ports:check\` GREEN
- No Go code touched → no \`task lint\` / \`task test\` deltas

## Possible follow-ups (out of scope here)

- Drift between \`ml-modules/{topic}/module.py\` and \`ml-sidecars/{topic}-ml/module.py\` (currently mirror manually)
- Folding \`ml-modules\`+\`ml-framework\` into \`ml-sidecars/\` (rejected — would lose dev live-edit ergonomics)
- Updating root \`ARCHITECTURE.md\` to reference the new READMEs

## Test plan

- [x] Both READMEs render correctly on GitHub
- [x] WP02 prompt file documents evidence
- [x] No code or compose changed
- [x] Gates green locally
- [ ] CI green on this PR

Closes #698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)