### PR TITLE
docs(mission-A WP03): document playwright-renderer (audit was wrong)

### DIFF
--- a/kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP03-playwright-renderer-triage.md
+++ b/kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP03-playwright-renderer-triage.md
@@ -1,0 +1,95 @@
+# WP03 — `playwright-renderer/` triage
+
+**Mission**: `audit-dead-code-removal-01KQG57Z`
+**Issue**: #699
+**Spec refs**: FR-004, FR-005, FR-007 (FR-004 conditional path)
+**Dependencies**: WP01, WP02
+
+## Outcome: documented, not deleted
+
+The 2026-04-30 audit's "no compose entry, no consumer" claim for `playwright-renderer/` was **incorrect**. The service is live in production with two consumers. Per spec FR-004's conditional clause (*"If unused (no compose entry, no service consumes its output), delete. Otherwise document and add to compose."*), this WP takes the **document the keeper** path. Adds `playwright-renderer/README.md` and `playwright-renderer/CLAUDE.md`. **No directory is deleted. No compose changed.**
+
+## Evidence the audit was wrong
+
+| Claim in audit | Reality |
+|---|---|
+| "Parallel to active `render-worker/`, no README, no `CLAUDE.md`, not in compose" | `render-worker/` parallel: true. No README/CLAUDE.md: true (addressed by this WP). **Not in compose: false** — present in `docker-compose.prod.yml` with full service definition (image, healthcheck, deploy resources). |
+| Implicit "no consumer" | False — two prod consumers reference it. |
+
+Verifying greps performed in this WP's worktree (origin/main HEAD `4ba80005`):
+
+```bash
+grep -l playwright-renderer docker-compose*.yml
+# → docker-compose.prod.yml (only)
+
+grep -B1 -A20 'playwright-renderer:' docker-compose.prod.yml
+# → full service definition at line 566:
+#     playwright-renderer:
+#       image: docker.io/jonesrussell/playwright-renderer:${PLAYWRIGHT_RENDERER_TAG:-latest}
+#       healthcheck: GET http://127.0.0.1:8095/health every 30s
+#       deploy: 1.0 CPU, 1G memory
+
+grep -B1 -A2 'RENDERER_URL' docker-compose.prod.yml
+# → mcp-north-cloud line 560: RENDERER_URL: "http://playwright-renderer:8095"
+# → signal-crawler line 829:  RENDERER_URL=http://playwright-renderer:8095, RENDERER_ENABLED=true
+```
+
+The audit likely scanned `docker-compose.base.yml` only and concluded "not in compose". The service is prod-only and not present in base/dev compose (use `render-worker/` for local rendering experiments).
+
+## Why `playwright-renderer/` and `render-worker/` both exist
+
+The audit also implied `playwright-renderer/` is redundant with the active `render-worker/`. They are not redundant — they serve different roles:
+
+| Aspect | `render-worker/` | `playwright-renderer/` |
+|---|---|---|
+| Port | 3000 | 8095 |
+| Container name | `north-cloud-render-worker` | `playwright-renderer` |
+| Built from | local Dockerfile (in base + prod compose) | published image `docker.io/jonesrussell/playwright-renderer` (prod compose only) |
+| Server | http stdlib + custom queue | express + simple concurrency limit |
+| Stealth / scroll | yes (`stealth.js`, `scroll.js`) | no |
+| Browser recycling | every 100 requests | persistent (no recycle) |
+| Resource blocking | unknown (handler-driven) | yes (image/media/font/CSS aborted) |
+| Concurrency | tab queue, max 1 | reject (503) at 3 in-flight |
+| Used by | crawler's main pipeline | mcp-north-cloud `fetch_url` + signal-crawler |
+| Design goal | sustained throughput inside crawl loop | on-demand rendering for ad-hoc consumers |
+
+Consolidating them is possible but would require migrating both consumers and reworking the crawler-side queue logic — out of scope for an audit deletion WP. Documented as a possible follow-up.
+
+## Changes in this WP
+
+| File | Action |
+|---|---|
+| `playwright-renderer/README.md` | **New** — purpose, consumers, API surface, configuration, deploy, "not the same as `render-worker/`" note, audit revision note |
+| `playwright-renderer/CLAUDE.md` | **New** — agent-facing quick-reference for editing this directory; cites the two consumers and the boundary with `render-worker/` |
+| `kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP03-playwright-renderer-triage.md` | **New** — this prompt file with full evidence |
+
+No code, compose, Taskfile, or workflow changed.
+
+## Out of scope (possible follow-ups)
+
+- **Add `playwright-renderer` to root `CLAUDE.md` orchestration table** — would simplify discovery. DIR-004 ("no while-I'm-here") declines doing it as part of this WP.
+- **Consolidate `playwright-renderer` and `render-worker`** — explicitly evaluated and rejected (different design goals; would require migrating two consumers + crawler queue logic).
+- **Add `docs/specs/playwright-renderer.md`** — the service is small with a single API surface; a spec entry isn't warranted yet.
+
+## Verification
+
+- `task drift:check` — green (no spec touched)
+- `task layers:check` — green (no Go imports changed)
+- `task ports:check` — green (no compose changed)
+- No Go code touched → no `task lint` / `task test` deltas
+
+## Acceptance
+
+- Both new docs land on `main`.
+- `playwright-renderer/` remains unchanged in code.
+- Issue #699 closed via `Closes #699`, with body explaining the audit revision and parallel to WP02.
+
+## Mission A retrospective (with WP01–03 complete)
+
+| WP | Issue | Audit's claim | Reality | Action taken |
+|---|---|---|---|---|
+| WP01 | #697 dashboard-waaseyaa | Orphaned PHP/Laravel rewrite | Confirmed orphaned (generic Waaseyaa CMS skeleton) | Deleted (96 files, ~14323 LOC) |
+| WP02 | #698 ml-modules + ml-framework | Orphaned siblings to ml-sidecars | Wrong — active 3-tier ML architecture | Documented (2 READMEs) |
+| WP03 | #699 playwright-renderer | "Not in compose, no consumer" | Wrong — prod compose service with 2 consumers | Documented (README + CLAUDE.md) |
+
+Mission A successfully removed one true orphan (dashboard-waaseyaa) and corrected two audit errors with documentation. Two-thirds of the audit's flagged "dead code" turned out to be live code lacking READMEs.

--- a/playwright-renderer/CLAUDE.md
+++ b/playwright-renderer/CLAUDE.md
@@ -1,0 +1,36 @@
+# playwright-renderer (CLAUDE.md)
+
+Lightweight headless-browser sidecar for on-demand JS page rendering. **Prod only.**
+
+## When you're working here
+
+- This is a small (3-file) Node.js + Express + Playwright service
+- Consumers in prod: `mcp-north-cloud` (`fetch_url` MCP tool with `js_render=true`) and `signal-crawler` (when `RENDERER_ENABLED=true`)
+- Not the same as `render-worker/` — see `render-worker/CLAUDE.md` for the crawler's main rendering pipeline. Don't consolidate without migrating both consumers.
+
+## Files
+
+- `server.js` — express app, two routes: `POST /render`, `GET /health`
+- `package.json` — declares deps `express ^4.18.2`, `playwright ^1.48.0`
+- `Dockerfile` — `FROM mcr.microsoft.com/playwright:v1.58.2-jammy`
+
+## Quick local test
+
+```bash
+docker run --rm -p 8095:8095 docker.io/jonesrussell/playwright-renderer:latest
+curl http://localhost:8095/health
+curl -X POST http://localhost:8095/render \
+  -H 'content-type: application/json' \
+  -d '{"url":"https://example.com"}' | jq -r .html | head -5
+```
+
+## Editing rules
+
+- Keep dependencies minimal — service is intentionally a thin wrapper around chromium
+- Concurrency cap stays low (default 3) — this is a single-tenant prod sidecar, not a high-throughput pipeline
+- Resource blocking (image/media/font/CSS) is intentional — do not relax without a benchmark showing it matters
+- Bumping the Playwright base image: also bump `package.json` `playwright` to a compatible version
+
+## Spec
+
+See `README.md` for full API + config + architecture context. No `docs/specs/` entry exists today (small service, single API surface — not yet warranted).

--- a/playwright-renderer/README.md
+++ b/playwright-renderer/README.md
@@ -1,0 +1,75 @@
+# playwright-renderer
+
+A lightweight headless-browser renderer sidecar. Deployed in **production only**, gated behind two consumers' opt-in env vars.
+
+## Purpose
+
+Renders JS-heavy pages on demand and returns the rendered HTML. Optimized for one-off requests (small concurrency cap, persistent browser, image/media/font/CSS resource blocking) rather than sustained pipeline throughput.
+
+## Consumers
+
+| Consumer | How | Compose entry |
+|---|---|---|
+| `mcp-north-cloud` (`fetch_url` MCP tool) | Sets `RENDERER_URL: "http://playwright-renderer:8095"`; called when `fetch_url` is invoked with `js_render=true` | `docker-compose.prod.yml` |
+| `signal-crawler` | Sets `RENDERER_URL=http://playwright-renderer:8095` and `RENDERER_ENABLED=true`; used per crawl when JS rendering is required | `docker-compose.prod.yml` |
+
+When neither consumer needs JS rendering, the sidecar is unused but still scheduled (cheap, idle resource cost).
+
+## Not the same as `render-worker/`
+
+`render-worker/` is the crawler's main rendering pipeline (port 3000, `north-cloud-render-worker` container). It uses queued requests, stealth scripts (`stealth.js`), infinite-scroll handling (`scroll.js`), browser recycling after N requests, and a custom HTTP handler. Its design goal is sustained throughput inside the crawl loop.
+
+`playwright-renderer/` (this directory, port 8095) is a smaller, simpler service for on-demand rendering outside the crawl loop. The two are intentionally separate; do not consolidate without migrating both consumers and the crawler-side queue logic.
+
+## Layout
+
+```
+playwright-renderer/
+├── package.json     # name = "playwright-renderer", v1.0.0; deps: express, playwright
+├── Dockerfile       # Built FROM mcr.microsoft.com/playwright:v1.58.2-jammy
+└── server.js        # Express app: POST /render, GET /health
+```
+
+## API
+
+### `POST /render`
+
+Request:
+```json
+{
+  "url": "https://example.com/article",
+  "wait_for": "networkidle",       // or "domcontentloaded"; default "networkidle"
+  "timeout_ms": 30000              // capped at 60000
+}
+```
+
+Response (200):
+```json
+{ "html": "<!DOCTYPE html>...", "url": "https://example.com/article" }
+```
+
+Errors: `400` if `url` missing, `503` if at concurrency cap, `500` on render failure.
+
+### `GET /health`
+
+Returns `{ "status": "ok", "active_requests": <int> }`.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `RENDERER_PORT` | `8095` | Listen port |
+| `RENDERER_TIMEOUT_MS` | `30000` | Per-request browser timeout (capped at 60s) |
+| `RENDERER_MAX_CONCURRENT` | `3` | Reject (503) when this many requests are in-flight |
+
+Resource blocking: the renderer aborts requests for `image`, `media`, `font`, and `stylesheet` resource types to keep render time fast (HTML/JS only).
+
+## Production deploy
+
+Deployed via `docker-compose.prod.yml` as `playwright-renderer` (image `docker.io/jonesrussell/playwright-renderer:${PLAYWRIGHT_RENDERER_TAG:-latest}`). 1 CPU / 1 GB memory limit. 30s healthcheck against `/health`.
+
+Not present in `docker-compose.base.yml` or `docker-compose.dev.yml` — use `render-worker/` (port 3000) for local rendering experiments.
+
+## Audit note (2026-04-30)
+
+The 2026-04-30 code-smell audit initially flagged this directory for deletion as "no compose entry, no consumer". That was incorrect — the audit checked `docker-compose.base.yml` only and missed both the prod compose entry and the two prod consumers. Mission A WP03 closed as "audit was wrong; service is live in prod". See `kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP03-...md` for evidence.


### PR DESCRIPTION
## Summary

Mission A WP03 (issue #699) — **the audit was wrong, again**. \`playwright-renderer/\` is not orphaned; it is a live prod-only sidecar with two consumers. Per spec FR-004's conditional ("If unused, delete; otherwise document"), this PR takes the **document-the-keeper** path — adds \`README.md\`, \`CLAUDE.md\`, and the WP03 prompt file. **No code, compose, Taskfile, or workflow changed.**

## Why the audit was wrong

| Audit claim | Reality |
|---|---|
| "Parallel to active render-worker/" | True, but they serve different roles (see below) |
| "No README, no CLAUDE.md" | True — fixed by this PR |
| "Not in compose" | **False** — full service definition in \`docker-compose.prod.yml\` line 566 |
| Implicit "no consumer" | **False** — \`mcp-north-cloud\` (\`fetch_url\` MCP tool with \`js_render=true\`) and \`signal-crawler\` (when \`RENDERER_ENABLED=true\`) both call it |

The audit likely scanned \`docker-compose.base.yml\` only and missed the prod entry.

## Why it's not redundant with \`render-worker/\`

Different design goals:

| | \`render-worker/\` | \`playwright-renderer/\` |
|---|---|---|
| Port | 3000 | 8095 |
| Built from | local Dockerfile (base + prod compose) | published image (prod compose only) |
| Server | http stdlib + custom queue | express + concurrency limit |
| Stealth + scroll | yes | no |
| Browser recycling | every 100 requests | persistent |
| Resource blocking | unknown | yes (image/media/font/CSS aborted) |
| Concurrency | tab queue, max 1 | reject (503) at 3 in-flight |
| Used by | crawler's main pipeline | mcp-north-cloud + signal-crawler |
| Design goal | sustained throughput inside crawl loop | on-demand renders for ad-hoc consumers |

Consolidating them would require migrating both consumers + reworking crawler-side queue logic. Out of scope for an audit deletion WP. Documented as a possible follow-up.

## Files added

| File | Purpose |
|---|---|
| \`playwright-renderer/README.md\` | Purpose, consumers, API surface, configuration, deploy, "not the same as render-worker/" note, audit revision note |
| \`playwright-renderer/CLAUDE.md\` | Agent-facing quick-reference for editing this directory |
| \`kitty-specs/audit-dead-code-removal-01KQG57Z/tasks/WP03-playwright-renderer-triage.md\` | WP03 prompt file with full evidence and Mission A retrospective |

## Mission A retrospective (with WP01–03 complete)

| WP | Issue | Audit's claim | Reality | Action |
|---|---|---|---|---|
| WP01 | #697 dashboard-waaseyaa | Orphaned PHP/Laravel rewrite | Confirmed orphaned (generic Waaseyaa CMS skeleton) | Deleted (96 files, ~14323 LOC) |
| WP02 | #698 ml-modules + ml-framework | Orphaned siblings to ml-sidecars | Wrong — active 3-tier ML architecture | Documented (2 READMEs) |
| WP03 | #699 playwright-renderer | "Not in compose, no consumer" | Wrong — prod compose service with 2 consumers | Documented (README + CLAUDE.md) |

**Two-thirds of the audit's "dead code" turned out to be live code lacking READMEs.** Worth flagging for the next audit pass: include prod compose and consumer-import grep, not just base/dev compose and classifier-side imports.

## Charter check

- **DIR-001** ✓ — playwright-renderer is in scope (consumed by content pipeline + signal-crawler); correcting audit error doesn't affect risk boundary
- **DIR-002** ✓ — adds documentation that was missing
- **DIR-003** ✓ — no Go code changed
- **DIR-004** ✓ — single PR for single WP, no abstractions added, didn't add to root CLAUDE.md table or open consolidation mission (out of scope, deferred)

## Gates verified locally

- \`task drift:check\` GREEN
- \`task layers:check\` GREEN
- \`task ports:check\` GREEN
- No Go code touched → no \`task lint\` / \`task test\` deltas

## Test plan

- [x] Both new docs render correctly on GitHub
- [x] WP03 prompt file documents evidence + Mission A retrospective
- [x] No code, compose, Taskfile, or workflow changed
- [x] Gates green locally
- [ ] CI green on this PR

Closes #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)